### PR TITLE
Separate Controller functions into separate class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,4 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
 /test.py
+.myt_app/

--- a/mytoyota/api.py
+++ b/mytoyota/api.py
@@ -1,265 +1,37 @@
-"""Toyota Connected Services Controller"""
-from datetime import datetime
+"""Toyota Connected Services API"""
 import logging
-from typing import Optional, Union
+from typing import Optional
 
-import httpx
-
-from .const import (
-    BASE_URL,
-    BASE_URL_CARS,
-    CUSTOMERPROFILE,
-    ENDPOINT_AUTH,
-    HTTP_INTERNAL,
-    HTTP_NO_CONTENT,
-    HTTP_OK,
-    HTTP_SERVICE_UNAVAILABLE,
-    PASSWORD,
-    SUPPORTED_REGIONS,
-    TIMEOUT,
-    TOKEN,
-    TOKEN_DURATION,
-    TOKEN_VALID_URL,
-    USERNAME,
-    UUID,
-)
-from .exceptions import ToyotaApiError, ToyotaInternalError, ToyotaLoginError
-from .utils import is_valid_token
+from .const import BASE_URL, BASE_URL_CARS
+from .controller import Controller
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-class Controller:
+class Api:
     """Controller class."""
 
     def __init__(  # pylint: disable=too-many-arguments
-        self,
-        locale: str,
-        region: str,
-        username: str,
-        password: str,
-        uuid: str,
+        self, controller: Controller
     ) -> None:
         """Toyota Controller"""
 
-        self.token = None
-        self.token_expiration: Optional[datetime] = None
-        self.uuid = None
+        self.controller = controller
 
-        if uuid is not None:
-            self.uuid = uuid
-
-        self.locale: str = locale
-        self.region: str = region
-
-        self.username: str = username
-        self.password: str = password
-
-    def get_base_url(self) -> str:
-        """Returns base url"""
-        return SUPPORTED_REGIONS[self.region][BASE_URL]
-
-    def get_base_url_cars(self) -> str:
-        """Returns base url for get_vehicles_endpoint"""
-        return SUPPORTED_REGIONS[self.region][BASE_URL_CARS]
-
-    def get_auth_endpoint(self) -> str:
-        """Returns auth endpoint"""
-        return SUPPORTED_REGIONS[self.region][ENDPOINT_AUTH]
-
-    def get_auth_valid_endpoint(self) -> str:
-        """Returns token is valid endpoint"""
-        return SUPPORTED_REGIONS[self.region][TOKEN_VALID_URL]
-
-    async def get_uuid(self) -> str:
-        """Returns uuid"""
-        return self.uuid
-
-    @staticmethod
-    def _has_expired(creation_dt: datetime, duration: int) -> bool:
-        """Checks if an specified token/object has expired"""
-        return datetime.now().timestamp() - creation_dt.timestamp() > duration
-
-    async def is_token_valid(self) -> bool:
-        """Checks if token is valid"""
-
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                self.get_auth_valid_endpoint(),
-                json={TOKEN: self.token},
-            )
-            if response.status_code == HTTP_OK:
-                result = response.json()
-
-                if result["valid"]:
-                    self.token_expiration = datetime.now()
-                    return True
-                return False
-
-            raise ToyotaLoginError(
-                "Error when trying to check token: {}".format(response.text)
-            )
-
-    async def get_new_token(self) -> str:
-        """Performs login to toyota servers and retrieves token and uuid for the account."""
-
-        headers = {
-            "X-TME-BRAND": "TOYOTA",
-            "X-TME-LC": self.locale,
-            "Accept": "application/json, text/plain, */*",
-            "Sec-Fetch-Dest": "empty",
-            "Content-Type": "application/json;charset=UTF-8",
-        }
-
-        # Cannot authenticate with aiohttp (returns 415),
-        # but it works with httpx.
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                self.get_auth_endpoint(),
-                headers=headers,
-                json={USERNAME: self.username, PASSWORD: self.password},
-            )
-            if response.status_code == HTTP_OK:
-                result = response.json()
-
-                if TOKEN not in result or UUID not in result[CUSTOMERPROFILE]:
-                    raise ToyotaLoginError("Could not get token or UUID from result")
-
-                token = result.get(TOKEN)
-                uuid = result[CUSTOMERPROFILE][UUID]
-
-                if is_valid_token(token):
-                    self.uuid = uuid
-                    self.token = token
-                    self.token_expiration = datetime.now()
-            else:
-                raise ToyotaLoginError(
-                    "Login failed, check your credentials! {}".format(response.text)
-                )
-
-        return self.token
-
-    async def get(
-        self,
-        endpoint: str,
-        headers: Optional[dict] = None,
-        params: Optional[dict] = None,
-    ) -> Union[dict, list, None]:
-        """Make the request."""
-
-        if self.token is None or self._has_expired(
-            self.token_expiration, TOKEN_DURATION
-        ):
-            if await self.is_token_valid() is False:
-                await self.get_new_token()
-
-        if headers is None:
-            headers = {}
-        headers.update(
-            {
-                "Cookie": f"iPlanetDirectoryPro={self.token}",
-                "uuid": self.uuid,
-                "Accept": "application/json, text/plain, */*",
-                "Sec-Fetch-Dest": "empty",
-                "X-TME-BRAND": "TOYOTA",
-                "X-TME-LC": self.locale,
-                "X-TME-LOCALE": self.locale,
-                "X-TME-TOKEN": self.token,
-            }
-        )
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                endpoint, headers=headers, params=params, timeout=TIMEOUT
-            )
-
-            if resp.status_code == HTTP_OK:
-                result = resp.json()
-            elif resp.status_code == HTTP_NO_CONTENT:
-                # This prevents raising or logging an error
-                # if the user have not setup Connected Services
-                result = None
-                _LOGGER.debug("Connected services is disabled")
-            elif resp.status_code == HTTP_INTERNAL:
-                response = resp.json()
-                raise ToyotaInternalError(
-                    "Internal server error occurred! Code: "
-                    + response["code"]
-                    + " - "
-                    + response["message"],
-                )
-            elif resp.status_code == HTTP_SERVICE_UNAVAILABLE:
-                raise ToyotaApiError(
-                    "Toyota Connected Services are temporarily unavailable"
-                )
-            else:
-                raise ToyotaInternalError(
-                    "HTTP: " + str(resp.status_code) + " - " + resp.text
-                )
-
-        return result
-
-    async def put(
-        self, endpoint: str, body: dict, headers: Optional[dict] = None
-    ) -> Union[dict, list, None]:
-        """Make the request."""
-
-        if self.token is None or self._has_expired(
-            self.token_expiration, TOKEN_DURATION
-        ):
-            if await self.is_token_valid() is False:
-                await self.get_new_token()
-
-        if headers is None:
-            headers = {}
-        headers.update(
-            {
-                "Accept": "application/json, text/plain, */*",
-                "Sec-Fetch-Dest": "empty",
-                "X-TME-BRAND": "TOYOTA",
-                "X-TME-LC": self.locale,
-                "X-TME-TOKEN": self.token,
-            }
-        )
-
-        async with httpx.AsyncClient() as client:
-            resp = await client.put(
-                endpoint, json=body, headers=headers, timeout=TIMEOUT
-            )
-
-            if resp.status_code == HTTP_OK:
-                result = resp.json()
-            elif resp.status_code == HTTP_NO_CONTENT:
-                # This prevents raising or logging an error
-                # if the user have not setup Connected Services
-                result = None
-                _LOGGER.debug("Connected services is disabled")
-            elif resp.status_code == HTTP_INTERNAL:
-                response = resp.json()
-                raise ToyotaInternalError(
-                    "Internal server error occurred! Code: "
-                    + response["code"]
-                    + " - "
-                    + response["message"],
-                )
-            elif resp.status_code == HTTP_SERVICE_UNAVAILABLE:
-                raise ToyotaApiError(
-                    "Toyota Connected Services are temporarily unavailable"
-                )
-            else:
-                raise ToyotaInternalError(
-                    "HTTP: " + str(resp.status_code) + " - " + resp.text
-                )
-
-            return result
+    async def uuid(self):
+        """Returns uuid from controller"""
+        return await self.controller.get_uuid()
 
     async def set_vehicle_alias_endpoint(
         self, new_alias: str, vehicle_id: int
     ) -> Optional[dict]:
         """Set vehicle alias."""
 
-        return await self.put(
-            f"{self.get_base_url_cars()}/api/users/{self.uuid}/vehicles/{vehicle_id}",
-            {"id": vehicle_id, "alias": new_alias},
+        return await self.controller.request(
+            method="PUT",
+            base_url=BASE_URL_CARS,
+            endpoint=f"/api/users/{await self.uuid()}/vehicles/{vehicle_id}",
+            body={"id": vehicle_id, "alias": new_alias},
         )
 
     async def get_vehicles_endpoint(self) -> Optional[list]:
@@ -267,8 +39,10 @@ class Controller:
 
         arguments = "?services=uio&legacy=true"
 
-        return await self.get(
-            f"{self.get_base_url_cars()}/vehicle/user/{self.uuid}/vehicles{arguments}"
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL_CARS,
+            endpoint=f"/vehicle/user/{await self.uuid()}/vehicles{arguments}",
         )
 
     async def get_connected_services_endpoint(self, vin: str) -> Optional[dict]:
@@ -276,27 +50,38 @@ class Controller:
 
         arguments = "?legacy=true&services=fud,connected"
 
-        return await self.get(
-            f"{self.get_base_url_cars()}/vehicle/user/{self.uuid}/vehicle/{vin}{arguments}"
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL_CARS,
+            endpoint=f"/vehicle/user/{await self.uuid()}/vehicle/{vin}{arguments}",
         )
 
     async def get_odometer_endpoint(self, vin: str) -> Optional[list]:
         """Get information from odometer."""
 
-        return await self.get(f"{self.get_base_url()}/vehicle/{vin}/addtionalInfo")
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL,
+            endpoint=f"/vehicle/{vin}/addtionalInfo",
+        )
 
     async def get_parking_endpoint(self, vin: str) -> Optional[dict]:
         """Get where you have parked your car."""
 
-        return await self.get(
-            f"{self.get_base_url()}/users/{self.uuid}/vehicle/location", {"VIN": vin}
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL,
+            endpoint=f"/users/{await self.uuid()}/vehicle/location",
+            headers={"VIN": vin},
         )
 
     async def get_vehicle_status_endpoint(self, vin: str) -> Optional[dict]:
         """Get information about the vehicle."""
 
-        return await self.get(
-            f"{self.get_base_url()}/users/{self.uuid}/vehicles/{vin}/vehicleStatus"
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL,
+            endpoint=f"/users/{await self.uuid()}/vehicles/{vin}/vehicleStatus",
         )
 
     async def get_driving_statistics_endpoint(
@@ -304,8 +89,10 @@ class Controller:
     ) -> Optional[dict]:
         """Get driving statistic"""
 
-        params = {"from": from_date, "calendarInterval": interval}
-
-        return await self.get(
-            f"{self.get_base_url()}/v2/trips/summarize", {"vin": vin}, params
+        return await self.controller.request(
+            method="GET",
+            base_url=BASE_URL,
+            endpoint="/v2/trips/summarize",
+            headers={"vin": vin},
+            params={"from": from_date, "calendarInterval": interval},
         )

--- a/mytoyota/client.py
+++ b/mytoyota/client.py
@@ -5,7 +5,7 @@ import logging
 
 import arrow
 
-from .api import Controller
+from .api import Api
 from .const import (
     DATE_FORMAT,
     DAY,
@@ -16,6 +16,7 @@ from .const import (
     WEEK,
     YEAR,
 )
+from .controller import Controller
 from .exceptions import (
     ToyotaInvalidUsername,
     ToyotaLocaleNotValid,
@@ -52,12 +53,14 @@ class MyT:
                 "Please provide a valid locale string! Valid format is: en-gb."
             )
 
-        self.api = Controller(
-            locale=locale,
-            region=region,
-            username=username,
-            password=password,
-            uuid=uuid,
+        self.api = Api(
+            Controller(
+                username=username,
+                password=password,
+                locale=locale,
+                region=region,
+                uuid=uuid,
+            )
         )
 
     @staticmethod
@@ -72,11 +75,11 @@ class MyT:
 
     async def login(self) -> None:
         """Login to Toyota services"""
-        await self.api.get_new_token()
+        await self.api.controller.first_login()
 
     async def get_uuid(self) -> str:
         """Get uuid"""
-        return await self.api.get_uuid()
+        return await self.api.uuid()
 
     async def set_alias(self, vehicle_id: int, new_alias: str) -> dict:
         """Sets a new alias for the car"""

--- a/mytoyota/const.py
+++ b/mytoyota/const.py
@@ -82,3 +82,10 @@ RETURNED_BAD_REQUEST = "bad_request"
 TME_B2C_ERR_CPSERVICES = "TME_B2C_ERR_CPSERVICES_GET_FAILURE"
 
 INTERVAL_SUPPORTED = ["day", "week", "isoweek", "month", "year"]
+
+BASE_HEADERS = {
+    "Content-Type": "application/json;charset=UTF-8",
+    "Accept": "application/json, text/plain, */*",
+    "Sec-Fetch-Dest": "empty",
+    "X-TME-BRAND": "TOYOTA",
+}

--- a/mytoyota/controller.py
+++ b/mytoyota/controller.py
@@ -1,0 +1,197 @@
+"""Toyota Connected Services Controller """
+
+from datetime import datetime
+import logging
+from typing import Optional, Union
+
+import httpx
+
+from mytoyota.const import (
+    BASE_HEADERS,
+    CUSTOMERPROFILE,
+    ENDPOINT_AUTH,
+    HTTP_INTERNAL,
+    HTTP_NO_CONTENT,
+    HTTP_OK,
+    HTTP_SERVICE_UNAVAILABLE,
+    PASSWORD,
+    SUPPORTED_REGIONS,
+    TIMEOUT,
+    TOKEN,
+    TOKEN_DURATION,
+    TOKEN_VALID_URL,
+    USERNAME,
+    UUID,
+)
+from mytoyota.exceptions import ToyotaApiError, ToyotaInternalError, ToyotaLoginError
+from mytoyota.utils import is_valid_token
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+class Controller:
+    """Httpx async client controller class"""
+
+    _token: str = None
+    _token_expiration: datetime = None
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        locale: str,
+        region: str,
+        username: str,
+        password: str,
+        uuid: str = None,
+    ) -> None:
+        self._locale = locale
+        self._region = region
+        self._username = username
+        self._password = password
+        self._uuid = uuid
+
+    def _build_auth_body(self) -> dict:
+        """Return auth body in a dict"""
+        return {USERNAME: self._username, PASSWORD: self._password}
+
+    def _get_auth_endpoint(self) -> str:
+        """Returns auth endpoint"""
+        return SUPPORTED_REGIONS[self._region][ENDPOINT_AUTH]
+
+    def _get_auth_valid_endpoint(self) -> str:
+        """Returns token is valid endpoint"""
+        return SUPPORTED_REGIONS[self._region][TOKEN_VALID_URL]
+
+    async def get_uuid(self) -> str:
+        """Returns uuid"""
+        return self._uuid
+
+    async def first_login(self) -> None:
+        """Perform first login"""
+        await self._update_token()
+
+    @staticmethod
+    def _has_expired(creation_dt: datetime, duration: int) -> bool:
+        """Checks if an specified token/object has expired"""
+        return datetime.now().timestamp() - creation_dt.timestamp() > duration
+
+    async def _update_token(self) -> None:
+        """Performs login to toyota servers and retrieves token and uuid for the account."""
+
+        # Cannot authenticate with aiohttp (returns 415),
+        # but it works with httpx.
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self._get_auth_endpoint(),
+                headers={"X-TME-LC": self._locale},
+                json=self._build_auth_body(),
+            )
+            if response.status_code == HTTP_OK:
+                result = response.json()
+
+                if TOKEN not in result or UUID not in result[CUSTOMERPROFILE]:
+                    raise ToyotaLoginError("Could not get token or UUID from result")
+
+                token = result.get(TOKEN)
+                uuid = result[CUSTOMERPROFILE][UUID]
+
+                if is_valid_token(token):
+                    self._uuid = uuid
+                    self._token = token
+                    self._token_expiration = datetime.now()
+            else:
+                raise ToyotaLoginError(
+                    "Login failed, check your credentials! {}".format(response.text)
+                )
+
+    async def _is_token_valid(self) -> bool:
+        """Checks if token is valid"""
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self._get_auth_valid_endpoint(),
+                json={TOKEN: self._token},
+            )
+            if response.status_code == HTTP_OK:
+                result = response.json()
+
+                if result["valid"]:
+                    return True
+                return False
+
+            raise ToyotaLoginError(
+                "Error when trying to check token: {}".format(response.text)
+            )
+
+    async def request(  # pylint: disable=too-many-arguments
+        self,
+        method: str,
+        endpoint: str,
+        base_url: Optional[str] = None,
+        body: Optional[dict] = None,
+        params: Optional[dict] = None,
+        headers: Optional[dict] = None,
+    ) -> Union[dict, list, None]:
+        """Shared request method"""
+
+        if headers is None:
+            headers = {}
+
+        if method not in ("GET", "POST", "PUT", "DELETE"):
+            raise ToyotaInternalError("Invalid request method provided")
+
+        if not self._token or self._has_expired(self._token_expiration, TOKEN_DURATION):
+            if not await self._is_token_valid():
+                await self._update_token()
+
+        if base_url:
+            url = SUPPORTED_REGIONS[self._region][base_url] + endpoint
+        else:
+            url = endpoint
+
+        headers.update(
+            {
+                "X-TME-LC": self._locale,
+                "X-TME-LOCALE": self._locale,
+                "X-TME-TOKEN": self._token,
+            }
+        )
+
+        if method in ("GET", "POST"):
+            headers.update(
+                {
+                    "Cookie": f"iPlanetDirectoryPro={self._token}",
+                    "uuid": self._uuid,
+                }
+            )
+
+        # Cannot authenticate with aiohttp (returns 415),
+        # but it works with httpx.
+        async with httpx.AsyncClient(headers=BASE_HEADERS, timeout=TIMEOUT) as client:
+            response = await client.request(
+                method, url, headers=headers, json=body, params=params
+            )
+            if response.status_code == HTTP_OK:
+                result = response.json()
+            elif response.status_code == HTTP_NO_CONTENT:
+                # This prevents raising or logging an error
+                # if the user have not setup Connected Services
+                result = None
+                _LOGGER.debug("Connected services is disabled")
+            elif response.status_code == HTTP_INTERNAL:
+                response = response.json()
+                raise ToyotaInternalError(
+                    "Internal server error occurred! Code: "
+                    + response["code"]
+                    + " - "
+                    + response["message"],
+                )
+            elif response.status_code == HTTP_SERVICE_UNAVAILABLE:
+                raise ToyotaApiError(
+                    "Toyota Connected Services are temporarily unavailable"
+                )
+            else:
+                raise ToyotaInternalError(
+                    "HTTP: " + str(response.status_code) + " - " + response.text
+                )
+
+        return result

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "anyio"
-version = "3.3.0"
+version = "3.3.1"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 category = "main"
 optional = false
@@ -250,7 +250,7 @@ http2 = ["h2 (>=3.0.0,<4.0.0)"]
 
 [[package]]
 name = "identify"
-version = "2.2.13"
+version = "2.2.14"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -538,8 +538,8 @@ content-hash = "fe66fd8bb5134e0726b4be9351128ba9228276e4bd701b671fef2d9fe88df7e3
 
 [metadata.files]
 anyio = [
-    {file = "anyio-3.3.0-py3-none-any.whl", hash = "sha256:929a6852074397afe1d989002aa96d457e3e1e5441357c60d03e7eea0e65e1b0"},
-    {file = "anyio-3.3.0.tar.gz", hash = "sha256:ae57a67583e5ff8b4af47666ff5651c3732d45fd26c929253748e796af860374"},
+    {file = "anyio-3.3.1-py3-none-any.whl", hash = "sha256:d7c604dd491eca70e19c78664d685d5e4337612d574419d503e76f5d7d1590bd"},
+    {file = "anyio-3.3.1.tar.gz", hash = "sha256:85913b4e2fec030e8c72a8f9f98092eeb9e25847a6e00d567751b77e34f856fe"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -617,8 +617,8 @@ httpx = [
     {file = "httpx-0.18.2.tar.gz", hash = "sha256:9f99c15d33642d38bce8405df088c1c4cfd940284b4290cacbfb02e64f4877c6"},
 ]
 identify = [
-    {file = "identify-2.2.13-py2.py3-none-any.whl", hash = "sha256:7199679b5be13a6b40e6e19ea473e789b11b4e3b60986499b1f589ffb03c217c"},
-    {file = "identify-2.2.13.tar.gz", hash = "sha256:7bc6e829392bd017236531963d2d937d66fc27cadc643ac0aba2ce9f26157c79"},
+    {file = "identify-2.2.14-py2.py3-none-any.whl", hash = "sha256:113a76a6ba614d2a3dd408b3504446bcfac0370da5995aa6a17fd7c6dffde02d"},
+    {file = "identify-2.2.14.tar.gz", hash = "sha256:32f465f3c48083f345ad29a9df8419a4ce0674bf4a8c3245191d65c83634bdbf"},
 ]
 idna = [
     {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},


### PR DESCRIPTION
This separates the api and controller functions into a new `Controller` class and renames the former `Controller` class to `Api` instead, now containing only endpoints.

This also simplifies the request function down to one function instead of one for each method.