### PR TITLE
Use Language.get to check the validity of the locale

### DIFF
--- a/mytoyota/utils.py
+++ b/mytoyota/utils.py
@@ -11,7 +11,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 def is_valid_locale(locale: str) -> bool:
     """Is locale string valid."""
-    return Language.make(locale).is_valid()
+    return Language.get(locale).is_valid()
 
 
 def is_valid_token(token: str) -> bool:


### PR DESCRIPTION
Will resolve the #73, in the situation that the latest langcodes library is used.
Is also working in the currently used 3.1.0 version of langcodes