### PR TITLE
Loosen version requirements for all dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ repository = "https://github.com/DurgNomis-drol/mytoyota"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-langcodes = "^3.1.0"
-httpx = "^0.18.1"
-arrow = "^1.1.1"
+langcodes = "^3.1"
+httpx = "^0.18"
+arrow = "^1.1"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^2.11.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/DurgNomis-drol/mytoyota"
 [tool.poetry.dependencies]
 python = "^3.7"
 langcodes = "^3.1"
-httpx = "^0.18"
+httpx = ">=0.18.2"
 arrow = "^1.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/DurgNomis-drol/mytoyota"
 [tool.poetry.dependencies]
 python = "^3.7"
 langcodes = "^3.1"
-httpx = ">=0.18.2"
+httpx = ">=0.18.1"
 arrow = "^1.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Closes #104 

There is no need for them to be so strict, I wasn't that familier with how to set this up when I did it. The only one that is important is `langcodes`, but i believe it is still in the correct range.