### PR TITLE
Code tweaks and minor refactoring of the rest

### DIFF
--- a/mytoyota/__init__.py
+++ b/mytoyota/__init__.py
@@ -1,1 +1,3 @@
 """Toyota Connected Services Client"""
+
+from .client import MyT  # pylint: disable=unused-import # NOQA

--- a/mytoyota/__init__.py
+++ b/mytoyota/__init__.py
@@ -8,4 +8,3 @@ except ModuleNotFoundError:
     import importlib_metadata
 
 __version__ = importlib_metadata.version(__name__)
-

--- a/mytoyota/api.py
+++ b/mytoyota/api.py
@@ -1,5 +1,7 @@
 """Toyota Connected Services API"""
-from typing import Optional
+from __future__ import annotations
+
+from typing import Any
 
 from .const import BASE_URL, BASE_URL_CARS
 from .controller import Controller
@@ -10,78 +12,69 @@ class Api:
 
     def __init__(self, controller: Controller) -> None:
         """Toyota Controller"""
-
         self.controller = controller
 
-    async def uuid(self):
+    @property
+    def uuid(self) -> str | None:
         """Returns uuid from controller"""
-        return await self.controller.get_uuid()
+        return self.controller.uuid
 
     async def set_vehicle_alias_endpoint(
         self, new_alias: str, vehicle_id: int
-    ) -> Optional[dict]:
+    ) -> dict[str, Any] | None:
         """Set vehicle alias."""
-
         return await self.controller.request(
             method="PUT",
             base_url=BASE_URL_CARS,
-            endpoint=f"/api/users/{await self.uuid()}/vehicles/{vehicle_id}",
+            endpoint=f"/api/users/{self.uuid}/vehicles/{vehicle_id}",
             body={"id": vehicle_id, "alias": new_alias},
         )
 
-    async def get_vehicles_endpoint(self) -> Optional[list]:
+    async def get_vehicles_endpoint(self) -> list[dict[str, Any] | None] | None:
         """Retrieves list of cars you have registered with MyT"""
-
-        arguments = "?services=uio&legacy=true"
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL_CARS,
-            endpoint=f"/vehicle/user/{await self.uuid()}/vehicles{arguments}",
+            endpoint=f"/vehicle/user/{self.uuid}/vehicles?services=uio&legacy=true",
         )
 
-    async def get_connected_services_endpoint(self, vin: str) -> Optional[dict]:
+    async def get_connected_services_endpoint(self, vin: str) -> dict[str, Any] | None:
         """Get information about connected services for the given car."""
-
-        arguments = "?legacy=true&services=fud,connected"
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL_CARS,
-            endpoint=f"/vehicle/user/{await self.uuid()}/vehicle/{vin}{arguments}",
+            endpoint=f"/vehicle/user/{self.uuid}/vehicle/{vin}?legacy=true&services=fud,connected",
         )
 
-    async def get_odometer_endpoint(self, vin: str) -> Optional[list]:
+    async def get_odometer_endpoint(self, vin: str) -> list[dict[str, Any]] | None:
         """Get information from odometer."""
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL,
             endpoint=f"/vehicle/{vin}/addtionalInfo",
         )
 
-    async def get_parking_endpoint(self, vin: str) -> Optional[dict]:
+    async def get_parking_endpoint(self, vin: str) -> dict[str, Any] | None:
         """Get where you have parked your car."""
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL,
-            endpoint=f"/users/{await self.uuid()}/vehicle/location",
+            endpoint=f"/users/{self.uuid}/vehicle/location",
             headers={"VIN": vin},
         )
 
-    async def get_vehicle_status_endpoint(self, vin: str) -> Optional[dict]:
+    async def get_vehicle_status_endpoint(self, vin: str) -> dict[str, Any] | None:
         """Get information about the vehicle."""
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL,
-            endpoint=f"/users/{await self.uuid()}/vehicles/{vin}/vehicleStatus",
+            endpoint=f"/users/{self.uuid}/vehicles/{vin}/vehicleStatus",
         )
 
-    async def get_vehicle_status_legacy_endpoint(self, vin: str) -> Optional[dict]:
+    async def get_vehicle_status_legacy_endpoint(
+        self, vin: str
+    ) -> dict[str, Any] | None:
         """Get information about the vehicle."""
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL,
@@ -89,10 +82,9 @@ class Api:
         )
 
     async def get_driving_statistics_endpoint(
-        self, vin: str, from_date: str, interval: Optional[str] = None
-    ) -> Optional[dict]:
+        self, vin: str, from_date: str, interval: str | None = None
+    ) -> dict[str, Any] | None:
         """Get driving statistic"""
-
         return await self.controller.request(
             method="GET",
             base_url=BASE_URL,

--- a/mytoyota/const.py
+++ b/mytoyota/const.py
@@ -16,10 +16,6 @@ SUPPORTED_REGIONS = {
     }
 }
 
-# LOGIN
-USERNAME = "username"
-PASSWORD = "password"
-
 # So we don't have to test the token if multiple endpoints is requested at the same time.
 TOKEN_DURATION = 900
 TOKEN_LENGTH = 114

--- a/tests/test_myt.py
+++ b/tests/test_myt.py
@@ -36,7 +36,8 @@ class OfflineController:
         self._password = password
         self._uuid = uuid
 
-    async def get_uuid(self) -> str:
+    @property
+    def uuid(self) -> str:
         """Returns uuid"""
         return "_OfflineController_"
 
@@ -210,7 +211,7 @@ class TestMyT:
     def test_get_uuid(self):
         """Test the retrieval of an uuid"""
         myt = self._create_offline_myt()
-        uuid = asyncio.get_event_loop().run_until_complete(myt.get_uuid())
+        uuid = myt.uuid
         assert uuid
         assert len(uuid) > 0
 


### PR DESCRIPTION
Nothing in here should be a breaking change except that the former `get_uuid()` in `MyT` object is now a `property` instead.

I also updated all the type annotations for this part to the modern standard as well.

You can now access the client object without importing it like `mytoyota.client`, now you can just use `from mytoyota import Myt`