### PR TITLE
Reduce specific version of release-drafter to 5.*.*

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-drafter
-        uses: release-drafter/release-drafter@v5.17.6
+        uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use only the 'v5' version specifier for the Release-Drafter, and not a very specific 5.1.7.6 version.
This will reduce lot of general PR of the dependabot.