### PR TITLE
Remove screenshot related question from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,8 +20,5 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
-
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
As the mytoyota library is a library without a userinterface, it is not logical to request for screenshots in the issue report template.