### PR TITLE
Do not use arrow/datetime.strptime to prevent embedded python exception

### DIFF
--- a/mytoyota/statistics.py
+++ b/mytoyota/statistics.py
@@ -115,9 +115,11 @@ class Statistics:
                 day[BUCKET].update(
                     {
                         UNIT: METRIC,
-                        DATE: self._now.strptime(f"{dayofyear} {year}", "%j %Y").format(
-                            DATE_FORMAT
-                        ),
+                        # As we use 1 january of the year as the initial date
+                        # we only have to shift it with 1 day less
+                        DATE: arrow.Arrow(year, 1, 1)
+                        .shift(days=dayofyear - 1)
+                        .format(DATE_FORMAT),
                     }
                 )
             return data[HISTOGRAM]


### PR DESCRIPTION
There is a known problem with datetime.strptime in an embedded Python interpreter. 
See: https://bugs.python.org/issue27400

As my [Domoticz-Toyota-Plugin][plugin] is run from within Domoticz, using embedded Python, the retrieval of the 'day' statistics is triggering this exception. To prevent that exception it is better to NOT use arrow.strptime (which calls datetime.strptime) or datetime.strptime. 

This PR is replacing the only arrow.strptime function call with another line of code that uses the arrow library to calculate the same date from the day-of-year information that is provided. 

A previous unittest (see: #138) has already been added to confirm that the changed implementation calculates the same date. That unittest is still passing. 

[plugin]: https://github.com/joro75/Domoticz-Toyota-Plugin