### PR TITLE
Exclude a few lines from coverage

### DIFF
--- a/mytoyota/api.py
+++ b/mytoyota/api.py
@@ -54,7 +54,9 @@ class Api:
             endpoint=f"/vehicle/{vin}/addtionalInfo",
         )
 
-    async def get_parking_endpoint(self, vin: str) -> dict[str, Any] | None:
+    async def get_parking_endpoint(
+        self, vin: str
+    ) -> dict[str, Any] | None:  # pragma: no cover
         """Get where you have parked your car."""
         return await self.controller.request(
             method="GET",

--- a/mytoyota/models/dashboard.py
+++ b/mytoyota/models/dashboard.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from mytoyota.utils.conversions import convert_to_miles
 
 if TYPE_CHECKING:
-    from mytoyota.models.vehicle import Vehicle
+    from mytoyota.models.vehicle import Vehicle  # pragma: no cover
 
 
 class Dashboard:

--- a/tests/test_myt.py
+++ b/tests/test_myt.py
@@ -64,7 +64,9 @@ class OfflineController:
         """Shared request method"""
 
         if method not in ("GET", "POST", "PUT", "DELETE"):
-            raise ToyotaInternalError("Invalid request method provided")
+            raise ToyotaInternalError(
+                "Invalid request method provided"
+            )  # pragma: no cover
 
         _ = base_url
 


### PR DESCRIPTION
These last few lines are very difficult to be tested with unittests, to excluded these 3 lines from the coverage statistics.
Based on the other unittests from the other Pull Requests, the total coverage should now be 100%, not including the controller.py file because that can only be tested with live communication with the toyota servers.