### PR TITLE
Include year and week as integers in statistical bucket data

### DIFF
--- a/mytoyota/const.py
+++ b/mytoyota/const.py
@@ -46,7 +46,6 @@ IMPERIAL = "imperial"
 IMPERIAL_LITERS = "imperial_liters"
 
 # DATE FORMATS
-DATE_FORMAT_YEAR = "YYYY"
 DATE_FORMAT = "YYYY-MM-DD"
 
 # HTTP

--- a/mytoyota/statistics.py
+++ b/mytoyota/statistics.py
@@ -9,7 +9,6 @@ from mytoyota.const import (
     DATA,
     DATE,
     DATE_FORMAT,
-    DATE_FORMAT_YEAR,
     DAY,
     DAYOFYEAR,
     HISTOGRAM,
@@ -127,8 +126,8 @@ class Statistics:
         if interval is ISOWEEK:
             data_with_bucket: dict = {
                 BUCKET: {
-                    YEAR: self._now.format(DATE_FORMAT_YEAR),
-                    WEEK: self._now.strftime("%V"),
+                    YEAR: self._now.year,
+                    WEEK: self._now.week,
                     UNIT: METRIC,
                     PERIODE_START: data["from"],
                 },
@@ -153,7 +152,7 @@ class Statistics:
         if interval is YEAR:
             data_with_bucket: dict = {
                 BUCKET: {
-                    YEAR: self._now.format(DATE_FORMAT_YEAR),
+                    YEAR: self._now.year,
                     UNIT: METRIC,
                     PERIODE_START: data["from"],
                 },

--- a/tests/test_myt.py
+++ b/tests/test_myt.py
@@ -429,9 +429,15 @@ class TestMyTStatistics(TestMyTHelper):
             ("week", "metric"),
             ("week", "imperial"),
             ("week", "imperial_liters"),
+            ("isoweek", "metric"),
+            ("isoweek", "imperial"),
+            ("isoweek", "imperial_liters"),
             ("month", "metric"),
             ("month", "imperial"),
             ("month", "imperial_liters"),
+            ("year", "metric"),
+            ("year", "imperial"),
+            ("year", "imperial_liters"),
         ],
     )
     def test_get_driving_statistics_contains_year_as_int(self, interval, unit):
@@ -447,31 +453,6 @@ class TestMyTStatistics(TestMyTHelper):
         for day_data in statistics:
             bucket = day_data["bucket"]
             assert isinstance(bucket["year"], int)
-
-    @pytest.mark.parametrize(
-        "interval,unit",
-        [
-            ("isoweek", "metric"),
-            ("isoweek", "imperial"),
-            ("isoweek", "imperial_liters"),
-            ("year", "metric"),
-            ("year", "imperial"),
-            ("year", "imperial_liters"),
-        ],
-    )
-    def test_get_driving_statistics_contains_year_as_str(self, interval, unit):
-        """Test that the statistics contains the year as a string"""
-        myt = self._create_offline_myt()
-        vehicle = self._lookup_vehicle(myt, 4444444)
-        assert vehicle is not None
-        # Retrieve the driving statistics of the vehicle
-        statistics = asyncio.get_event_loop().run_until_complete(
-            myt.get_driving_statistics(vehicle["vin"], interval, unit=unit)
-        )
-        assert statistics is not None
-        for day_data in statistics:
-            bucket = day_data["bucket"]
-            assert isinstance(bucket["year"], str)
 
     @pytest.mark.parametrize(
         "interval",


### PR DESCRIPTION
Fixes: #139: The 'year' information in the 'bucket' of the statistics is sometimes a string and sometimes an integer

The year and week are now always included as integers in the 'bucket' dictionary that is part of the driving statistics.
