### PR TITLE
Create codecov.yml configuration file to relax approving PR

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        # allow a 2% drop from the previous base commit coverage
+        target: auto
+        threshold: 2%
+        # See status checks but prevent them from blocking
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Provide a codecov configuration file that relaxes the codecov check that is required to approve the PR.
In the previous configuration a change of -0.01% of coverage blocked the pull request.
With this configuration a warning is only raised if the coverage is going 2% down. And because it is informational, it will still not block the actual PR.

Also see: https://docs.codecov.com/docs/common-recipe-list