### PR TITLE
Adjust GitHub workflows to also run for v0.7 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,13 @@ name: Build package
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - 'v0.7'
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - 'v0.7'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,11 @@ on:
   push:
     branches:
       - master
-      - 'v0.7'
+      - "v0.7"
   pull_request:
     branches:
       - master
-      - 'v0.7'
+      - "v0.7"
 
 jobs:
   build:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'v0.7'
   pull_request:
 
 jobs:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'v0.7'
+      - "v0.7"
   pull_request:
 
 jobs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'v0.7'
 
 jobs:
   draft_release:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - 'v0.7'
+      - "v0.7"
 
 jobs:
   draft_release:


### PR DESCRIPTION
The linting, building and checking will now also be done for the 'v0.7' branch, so it will allow that the 'v0.7' branch is also supported and working, beside the master branch.