### PR TITLE
Convert too long line of User-Agent into shorter python code

### DIFF
--- a/mytoyota/const.py
+++ b/mytoyota/const.py
@@ -62,7 +62,9 @@ BASE_HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "Sec-Fetch-Dest": "empty",
     "X-TME-BRAND": "TOYOTA",
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+    "User-Agent": ("Mozilla/5.0 (X11; Linux x86_64) '
+                   'AppleWebKit/537.36 (KHTML, like Gecko) '
+                   'Chrome/51.0.2704.103 Safari/537.36'),
 }
 
 # Timestamps


### PR DESCRIPTION
Resolves the pylint error that is triggered by the too long line of code.