### PR TITLE
Added support for Lexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ from mytoyota.client import MyT
 
 username = "jane@doe.com"
 password = "MyPassword"
+brand = "toyota"  # or lexus
 
 # Get supported regions, can be passed to the optional 'region' argument of MyT
 # At this moment, only the 'europe' region is supported
 print(MyT.get_supported_regions())
 
-client = MyT(username=username, password=password)
-
+client = MyT(username=username, password=password, brand=brand)
 
 async def get_information():
     print("Logging in...")

--- a/mytoyota/client.py
+++ b/mytoyota/client.py
@@ -63,7 +63,8 @@ class MyT:
         password: str,
         locale: str = "da-dk",
         region: str = "europe",
-        uuid: str = None,
+        brand: str = "toyota",
+        uuid: str | None = None,
         controller_class=Controller,
         disable_locale_check: bool = False,
     ) -> None:
@@ -87,6 +88,7 @@ class MyT:
                 password=password,
                 locale=locale,
                 region=region,
+                brand=brand,
                 uuid=uuid,
             )
         )

--- a/mytoyota/const.py
+++ b/mytoyota/const.py
@@ -61,7 +61,6 @@ BASE_HEADERS = {
     "Content-Type": "application/json;charset=UTF-8",
     "Accept": "application/json, text/plain, */*",
     "Sec-Fetch-Dest": "empty",
-    "X-TME-BRAND": "TOYOTA",
     "User-Agent": (
         "Mozilla/5.0 (X11; Linux x86_64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "

--- a/mytoyota/controller.py
+++ b/mytoyota/controller.py
@@ -43,12 +43,14 @@ class Controller:
         region: str,
         username: str,
         password: str,
+        brand: str,
         uuid: str | None = None,
     ) -> None:
         self._locale = locale
         self._region = region
         self._username = username
         self._password = password
+        self._brand = brand
         self._uuid = uuid
 
     @property
@@ -176,6 +178,7 @@ class Controller:
                 "X-TME-LOCALE": self._locale,
                 "X-TME-TOKEN": self._token,
                 "X-TME-APP-VERSION": "4.10.0",
+                "X-TME-BRAND": self._brand.upper(),
             }
         )
 

--- a/tests/test_myt.py
+++ b/tests/test_myt.py
@@ -32,12 +32,14 @@ class OfflineController:
         region: str,
         username: str,
         password: str,
+        brand: str,
         uuid: str = None,
     ) -> None:
         self._locale = locale
         self._region = region
         self._username = username
         self._password = password
+        self._brand = brand
         self._uuid = uuid
 
     @property


### PR DESCRIPTION
By exposing the brand as a parameter, the library can be used for Lexus as well. I have tested this with my Lexus UX300e, and works as expected.  