### PR TITLE
Enhancement: install dependencies `--without dev` in package build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           poetry-version: 1.5.1
       - name: "⚙️ Install dependencies"
-        run: "poetry install"
+        run: "poetry install --without dev"
       - name: "🚀 Test package building"
         run: "poetry build"


### PR DESCRIPTION
Hello, with this MR some of the workflow changes we have made in the course of the API changeover will be outsourced.

Currently, the dev dependencies are also installed for the package build. 
This is not necessary. We can save some time and have a more meaningful result if we exclude the dev dependencies in the build process using poetry `--without dev`.