### PR TITLE
Fix car door lock status

### DIFF
--- a/mytoyota/models/lock_status.py
+++ b/mytoyota/models/lock_status.py
@@ -72,7 +72,7 @@ class Door:
         """If the door is locked."""
         if _get_status(self._status, status="carstatus_locked") is True:
             return True
-        if _get_status(self._status, status="carstatus_unlocked") is True:
+        if _get_status(self._status, status="carstatus_unlocked") is False:
             return False
         else:
             return None

--- a/mytoyota/models/lock_status.py
+++ b/mytoyota/models/lock_status.py
@@ -70,7 +70,12 @@ class Door:
     @property
     def locked(self) -> Optional[bool]:
         """If the door is locked."""
-        return _get_status(self._status, status="carstatus_locked")
+        if _get_status(self._status, status="carstatus_locked") is True:
+            return True
+        if _get_status(self._status, status="carstatus_unlocked") is True:
+            return False
+        else:
+            return None
 
 
 class Doors:


### PR DESCRIPTION
I happened to notice today that the current approach for determining locked doors returns `None` for unlocked doors.
Toyota's API handles these things really strangely. 😕 
Instead of setting the values for `carstatus_locked` to `True` and `False` accordingly, a separate `carstatus_unlocked` value is passed for unlocked doors.