### PR TITLE
Downgrade poetry-publish action to 1.16

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
       - name: "🚀 Build package and publish to pypi"
-        uses: "JRubics/poetry-publish@v1.17"
+        uses: "JRubics/poetry-publish@v1.16"
         with:
           pypi_token: "${{ secrets.PYPI_PASSWORD }}"
           plugins: "poetry-dynamic-versioning[plugin]"


### PR DESCRIPTION
Downgrade poetry-publish action to 1.16 due to current error in version 1.17: https://github.com/DurgNomis-drol/mytoyota/issues/275