### PR TITLE
Fix: Make `fuel_level` and `fuel_range` optional

### DIFF
--- a/mytoyota/models/endpoints/electric.py
+++ b/mytoyota/models/endpoints/electric.py
@@ -31,8 +31,8 @@ class ElectricStatusModel(BaseModel):
     charging_status: str = Field(alias="chargingStatus")
     ev_range: UnitValueModel = Field(alias="evRange")
     ev_range_with_ac: UnitValueModel = Field(alias="evRangeWithAc")
-    fuel_level: int = Field(alias="fuelLevel")
-    fuel_range: UnitValueModel = Field(alias="fuelRange")
+    fuel_level: Optional[int] = Field(alias="fuelLevel", default=None)
+    fuel_range: Optional[UnitValueModel] = Field(alias="fuelRange", default=None)
     last_update_timestamp: datetime = Field(alias="lastUpdateTimestamp")
     remaining_charge_time: Optional[int] = Field(
         alias="remainingChargeTime",


### PR DESCRIPTION
It looks as if no `fuel_level` and `fuel_range` will be reported for fully electric vehicles such as the bz4x.
With this MR, the two fields in the `ElectricStatusModel` are therefore made `Optional`.
Please also see: https://github.com/DurgNomis-drol/mytoyota/issues/277#issuecomment-1880126616