### PR TITLE
Fix: Inconsistency in statistics summaries

### DIFF
--- a/mytoyota/models/vehicle.py
+++ b/mytoyota/models/vehicle.py
@@ -235,7 +235,7 @@ class Vehicle:
         from_date: date,
         to_date: date,
         summary_type: SummaryType = SummaryType.MONTHLY,
-    ) -> Optional[List[Summary]]:
+    ) -> List[Summary]:
         """Return a Daily, Weekly, Monthly or Yearly summary between the provided dates.
 
         All but Daily can return a partial time range. For example if the summary_type is weekly

--- a/mytoyota/models/vehicle.py
+++ b/mytoyota/models/vehicle.py
@@ -434,7 +434,9 @@ class Vehicle:
 
                 if next_month is None or next_month.year != month.year:
                     end_date = min(to_date, date(day=31, month=12, year=summary_month.year))
-                    ret.append(Summary(build_summary, self._metric, start_date, end_date, build_hdc))
+                    ret.append(
+                        Summary(build_summary, self._metric, start_date, end_date, build_hdc)
+                    )
                     if next_month:
                         start_date = date(day=1, month=next_month.month, year=next_month.year)
                         build_hdc = copy.copy(next_month.hdc)


### PR DESCRIPTION
Fix issue: https://github.com/DurgNomis-drol/mytoyota/issues/281

- Fix for double addition for first item in a year
- Fix for only single month being returned in a year summary
- Fix for no data being returned. This happens when there has no been "driving" days in the date range requested.