### PR TITLE
Fix: Make `fugage` and `rage` optional

### DIFF
--- a/mytoyota/models/endpoints/status.py
+++ b/mytoyota/models/endpoints/status.py
@@ -44,8 +44,8 @@ class VehicleStatusModel(BaseModel):
 
 
 class _TelemetryModel(BaseModel):
-    fugage: UnitValueModel
-    rage: UnitValueModel
+    fugage: Optional[UnitValueModel] = None
+    rage: Optional[UnitValueModel] = None
     odo: UnitValueModel
 
 


### PR DESCRIPTION
Fix https://github.com/DurgNomis-drol/mytoyota/issues/280
It seems that some car models like the bz4x doesn't report any `fugage` and `rage` values for their remote status.