### PR TITLE
Fix: Make `unit` and `value` optional

### DIFF
--- a/mytoyota/models/endpoints/common.py
+++ b/mytoyota/models/endpoints/common.py
@@ -16,8 +16,8 @@ class UnitValueModel(BaseModel):
 
     """
 
-    unit: str
-    value: float
+    unit: Optional[str] = None
+    value: Optional[float] = None
 
 
 class _MessageModel(BaseModel):


### PR DESCRIPTION
The Toyota API is really strange in some places.
Why should I return `unit` and `value` but then leave them empty 😕 
See: https://github.com/DurgNomis-drol/mytoyota/issues/280#issuecomment-1883129546