### PR TITLE
Fix: Make `fuel_level` optional

### DIFF
--- a/mytoyota/models/endpoints/telemetry.py
+++ b/mytoyota/models/endpoints/telemetry.py
@@ -14,7 +14,7 @@ class TelemetryModel(BaseModel):
     ----------
         fuel_type (str): The type of fuel.
         odometer (UnitValueModel): The odometer reading.
-        fuel_level (int): The fuel level.
+        fuel_level (Optional[int]): The fuel level.
         distance_to_empty (Optional[UnitValueModel], optional): The estimated distance to empty. \n
             Defaults to None.
         timestamp (datetime): The timestamp of the telemetry data.

--- a/mytoyota/models/endpoints/telemetry.py
+++ b/mytoyota/models/endpoints/telemetry.py
@@ -23,7 +23,7 @@ class TelemetryModel(BaseModel):
 
     fuel_type: str = Field(alias="fuelType")
     odometer: UnitValueModel
-    fuel_level: int = Field(alias="fuelLevel")
+    fuel_level: Optional[int] = Field(alias="fuelLevel", default=None)
     distance_to_empty: Optional[UnitValueModel] = Field(alias="distanceToEmpty", default=None)
     timestamp: datetime
 


### PR DESCRIPTION
`fuel_level` isn ot reported by full electrical vehicles like the bz4x in the `TelemetryModel`.
See https://github.com/DurgNomis-drol/mytoyota/issues/280#issuecomment-1883866366