### PR TITLE
Enahncement: Set default log level to `ERROR` and log to stdout

### DIFF
--- a/mytoyota/utils/logging/log_config.yaml
+++ b/mytoyota/utils/logging/log_config.yaml
@@ -7,11 +7,10 @@ formatters:
     datefmt: "%Y-%m-%d %H:%M:%S"
 
 handlers:
-  file:
-    class: "logging.FileHandler"
+  stream:
+    class: "logging.StreamHandler"
     formatter: "simple"
-    filename: ".log"
-    mode: "w"
+    stream: sys.stdout
     filters:
       - "logfilter"
 
@@ -28,6 +27,6 @@ filters:
       - "guid':\\s*'([^']*)"
 
 root:
-  level: "DEBUG"
+  level: "ERROR"
   handlers:
-    - "file"
+    - "stream"

--- a/simple_client_example.py
+++ b/simple_client_example.py
@@ -10,7 +10,8 @@ from mytoyota.client import MyT
 from mytoyota.models.summary import SummaryType
 
 pp = pprint.PrettyPrinter(indent=4)
-logger = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
+
 
 # Set your username and password in a file on top level called "credentials.json" in the format:
 #   {


### PR DESCRIPTION
After playing around with the log again and seeing this comment (https://github.com/DurgNomis-drol/mytoyota/issues/299), I thought it might be better to set the default log level to `ERROR` and log to the stdout instead of a file.
Sorry for the noise