### PR TITLE
Fix: Make `VehicleReponseModel` values optional

### DIFF
--- a/mytoyota/models/endpoints/vehicle_guid.py
+++ b/mytoyota/models/endpoints/vehicle_guid.py
@@ -17,9 +17,7 @@ class _TranslationModel(BaseModel):
 class _CapabilitiesModel(BaseModel):
     description: Optional[str]
     display: bool
-    display_name: Optional[Any] = Field(
-        alias="displayName"
-    )  # TODO unsure what this returns
+    display_name: Optional[Any] = Field(alias="displayName")  # TODO unsure what this returns
     name: str
     translation: _TranslationModel
 
@@ -32,12 +30,8 @@ class _ExtendedCapabilitiesModel(BaseModel):
     buzzer_capable: bool = Field(alias="buzzerCapable")
     charge_management: bool = Field(alias="chargeManagement")
     climate_capable: bool = Field(alias="climateCapable")
-    climate_temperature_control_full: bool = Field(
-        alias="climateTemperatureControlFull"
-    )
-    climate_temperature_control_limited: bool = Field(
-        alias="climateTemperatureControlLimited"
-    )
+    climate_temperature_control_full: bool = Field(alias="climateTemperatureControlFull")
+    climate_temperature_control_limited: bool = Field(alias="climateTemperatureControlLimited")
     dashboard_warning_lights: bool = Field(alias="dashboardWarningLights")
     door_lock_unlock_capable: bool = Field(alias="doorLockUnlockCapable")
     drive_pulse: bool = Field(alias="drivePulse")
@@ -46,9 +40,7 @@ class _ExtendedCapabilitiesModel(BaseModel):
     econnect_vehicle_status_capable: bool = Field(alias="econnectVehicleStatusCapable")
     electric_pulse: bool = Field(alias="electricPulse")
     emergency_assist: bool = Field(alias="emergencyAssist")
-    enhanced_security_system_capable: bool = Field(
-        alias="enhancedSecuritySystemCapable"
-    )
+    enhanced_security_system_capable: bool = Field(alias="enhancedSecuritySystemCapable")
     equipped_with_alarm: bool = Field(alias="equippedWithAlarm")
     ev_battery: bool = Field(alias="evBattery")
     ev_charge_stations_capable: bool = Field(alias="evChargeStationsCapable")
@@ -61,13 +53,9 @@ class _ExtendedCapabilitiesModel(BaseModel):
     front_driver_seat_ventilation: bool = Field(alias="frontDriverSeatVentilation")
     front_passenger_door_lock_status: bool = Field(alias="frontPassengerDoorLockStatus")
     front_passenger_door_open_status: bool = Field(alias="frontPassengerDoorOpenStatus")
-    front_passenger_door_window_status: bool = Field(
-        alias="frontPassengerDoorWindowStatus"
-    )
+    front_passenger_door_window_status: bool = Field(alias="frontPassengerDoorWindowStatus")
     front_passenger_seat_heater: bool = Field(alias="frontPassengerSeatHeater")
-    front_passenger_seat_ventilation: bool = Field(
-        alias="frontPassengerSeatVentilation"
-    )
+    front_passenger_seat_ventilation: bool = Field(alias="frontPassengerSeatVentilation")
     fuel_level_available: bool = Field(alias="fuelLevelAvailable")
     fuel_range_available: bool = Field(alias="fuelRangeAvailable")
     guest_driver: bool = Field(alias="guestDriver")
@@ -93,9 +81,7 @@ class _ExtendedCapabilitiesModel(BaseModel):
     rear_hatch_rear_window: bool = Field(alias="rearHatchRearWindow")
     rear_passenger_door_lock_status: bool = Field(alias="rearPassengerDoorLockStatus")
     rear_passenger_door_open_status: bool = Field(alias="rearPassengerDoorOpenStatus")
-    rear_passenger_door_window_status: bool = Field(
-        alias="rearPassengerDoorWindowStatus"
-    )
+    rear_passenger_door_window_status: bool = Field(alias="rearPassengerDoorWindowStatus")
     rear_passenger_seat_heater: bool = Field(alias="rearPassengerSeatHeater")
     rear_passenger_seat_ventilation: bool = Field(alias="rearPassengerSeatVentilation")
     remote_econnect_capable: bool = Field(alias="remoteEConnectCapable")
@@ -103,9 +89,7 @@ class _ExtendedCapabilitiesModel(BaseModel):
     smart_key_status: bool = Field(alias="smartKeyStatus")
     steering_heater: bool = Field(alias="steeringHeater")
     stellantis_climate_capable: bool = Field(alias="stellantisClimateCapable")
-    stellantis_vehicle_status_capable: bool = Field(
-        alias="stellantisVehicleStatusCapable"
-    )
+    stellantis_vehicle_status_capable: bool = Field(alias="stellantisVehicleStatusCapable")
     sunroof: bool = Field(alias="sunroof")
     telemetry_capable: bool = Field(alias="telemetryCapable")
     trunk_lock_unlock_capable: bool = Field(alias="trunkLockUnlockCapable")
@@ -134,25 +118,17 @@ class _DcmModel(BaseModel):  # Data connection model
     supplier_name: str = Field(alias="dcmSupplierName")
     euicc_id: str = Field(alias="euiccid")
     hardware_type: Optional[str] = Field(alias="hardwareType")
-    vehicle_unit_terminal_number: Optional[str] = Field(
-        alias="vehicleUnitTerminalNumber"
-    )
+    vehicle_unit_terminal_number: Optional[str] = Field(alias="vehicleUnitTerminalNumber")
 
 
 class _HeadUnitModel(BaseModel):
-    description: Optional[Any] = Field(
-        alias="huDescription"
-    )  # TODO unsure what this returns
-    generation: Optional[Any] = Field(
-        alias="huGeneration"
-    )  # TODO unsure what this returns
+    description: Optional[Any] = Field(alias="huDescription")  # TODO unsure what this returns
+    generation: Optional[Any] = Field(alias="huGeneration")  # TODO unsure what this returns
     version: Optional[Any] = Field(alias="huVersion")  # TODO unsure what this returns
     mobile_platform_code: Optional[Any] = Field(
         alias="mobilePlatformCode"
     )  # TODO unsure what this returns
-    multimedia_type: Optional[Any] = Field(
-        alias="multimediaType"
-    )  # TODO unsure what this returns
+    multimedia_type: Optional[Any] = Field(alias="multimediaType")  # TODO unsure what this returns
 
 
 class _SubscriptionsModel(BaseModel):
@@ -400,16 +376,12 @@ class VehicleGuidModel(BaseModel):
     display_subscriptions: Optional[List[Dict[str, str]]] = Field(
         alias="displaySubscriptions", default=None
     )
-    electrical_platform_code: Optional[str] = Field(
-        alias="electricalPlatformCode", default=None
-    )
+    electrical_platform_code: Optional[str] = Field(alias="electricalPlatformCode", default=None)
     emergency_contact: Optional[Any] = Field(
         alias="emergencyContact"
     )  # TODO unsure what this returns
     ev_vehicle: bool = Field(alias="evVehicle")
-    extended_capabilities: _ExtendedCapabilitiesModel = Field(
-        alias="extendedCapabilities"
-    )
+    extended_capabilities: _ExtendedCapabilitiesModel = Field(alias="extendedCapabilities")
     external_subscriptions: Optional[Any] = Field(alias="externalSubscriptions")
     family_sharing: bool = Field(alias="familySharing")
     faq_url: str = Field(alias="faqUrl")
@@ -439,9 +411,7 @@ class VehicleGuidModel(BaseModel):
     primary_subscriber: bool = Field(alias="primarySubscriber")
     region: str
     registration_number: Optional[str] = Field(alias="registrationNumber")
-    remote_display: Optional[Any] = Field(
-        alias="remoteDisplay"
-    )  # TODO unsure what this returns
+    remote_display: Optional[Any] = Field(alias="remoteDisplay")  # TODO unsure what this returns
     remote_service_capabilities: _RemoteServiceCapabilitiesModel = Field(
         alias="remoteServiceCapabilities"
     )
@@ -453,9 +423,7 @@ class VehicleGuidModel(BaseModel):
         alias="remoteSubscriptionStatus", default=None
     )
     remote_user: bool = Field(alias="remoteUser")
-    remote_user_guid: Optional[Union[UUID, str]] = Field(
-        alias="remoteUserGuid", default=None
-    )
+    remote_user_guid: Optional[Union[UUID, str]] = Field(alias="remoteUserGuid", default=None)
     service_connect_status: Optional[Any] = Field(
         alias="serviceConnectStatus"
     )  # TODO unsure what this returns

--- a/mytoyota/models/endpoints/vehicle_guid.py
+++ b/mytoyota/models/endpoints/vehicle_guid.py
@@ -17,7 +17,9 @@ class _TranslationModel(BaseModel):
 class _CapabilitiesModel(BaseModel):
     description: Optional[str]
     display: bool
-    display_name: Optional[Any] = Field(alias="displayName")  # TODO unsure what this returns
+    display_name: Optional[Any] = Field(
+        alias="displayName"
+    )  # TODO unsure what this returns
     name: str
     translation: _TranslationModel
 
@@ -30,8 +32,12 @@ class _ExtendedCapabilitiesModel(BaseModel):
     buzzer_capable: bool = Field(alias="buzzerCapable")
     charge_management: bool = Field(alias="chargeManagement")
     climate_capable: bool = Field(alias="climateCapable")
-    climate_temperature_control_full: bool = Field(alias="climateTemperatureControlFull")
-    climate_temperature_control_limited: bool = Field(alias="climateTemperatureControlLimited")
+    climate_temperature_control_full: bool = Field(
+        alias="climateTemperatureControlFull"
+    )
+    climate_temperature_control_limited: bool = Field(
+        alias="climateTemperatureControlLimited"
+    )
     dashboard_warning_lights: bool = Field(alias="dashboardWarningLights")
     door_lock_unlock_capable: bool = Field(alias="doorLockUnlockCapable")
     drive_pulse: bool = Field(alias="drivePulse")
@@ -40,7 +46,9 @@ class _ExtendedCapabilitiesModel(BaseModel):
     econnect_vehicle_status_capable: bool = Field(alias="econnectVehicleStatusCapable")
     electric_pulse: bool = Field(alias="electricPulse")
     emergency_assist: bool = Field(alias="emergencyAssist")
-    enhanced_security_system_capable: bool = Field(alias="enhancedSecuritySystemCapable")
+    enhanced_security_system_capable: bool = Field(
+        alias="enhancedSecuritySystemCapable"
+    )
     equipped_with_alarm: bool = Field(alias="equippedWithAlarm")
     ev_battery: bool = Field(alias="evBattery")
     ev_charge_stations_capable: bool = Field(alias="evChargeStationsCapable")
@@ -53,9 +61,13 @@ class _ExtendedCapabilitiesModel(BaseModel):
     front_driver_seat_ventilation: bool = Field(alias="frontDriverSeatVentilation")
     front_passenger_door_lock_status: bool = Field(alias="frontPassengerDoorLockStatus")
     front_passenger_door_open_status: bool = Field(alias="frontPassengerDoorOpenStatus")
-    front_passenger_door_window_status: bool = Field(alias="frontPassengerDoorWindowStatus")
+    front_passenger_door_window_status: bool = Field(
+        alias="frontPassengerDoorWindowStatus"
+    )
     front_passenger_seat_heater: bool = Field(alias="frontPassengerSeatHeater")
-    front_passenger_seat_ventilation: bool = Field(alias="frontPassengerSeatVentilation")
+    front_passenger_seat_ventilation: bool = Field(
+        alias="frontPassengerSeatVentilation"
+    )
     fuel_level_available: bool = Field(alias="fuelLevelAvailable")
     fuel_range_available: bool = Field(alias="fuelRangeAvailable")
     guest_driver: bool = Field(alias="guestDriver")
@@ -81,7 +93,9 @@ class _ExtendedCapabilitiesModel(BaseModel):
     rear_hatch_rear_window: bool = Field(alias="rearHatchRearWindow")
     rear_passenger_door_lock_status: bool = Field(alias="rearPassengerDoorLockStatus")
     rear_passenger_door_open_status: bool = Field(alias="rearPassengerDoorOpenStatus")
-    rear_passenger_door_window_status: bool = Field(alias="rearPassengerDoorWindowStatus")
+    rear_passenger_door_window_status: bool = Field(
+        alias="rearPassengerDoorWindowStatus"
+    )
     rear_passenger_seat_heater: bool = Field(alias="rearPassengerSeatHeater")
     rear_passenger_seat_ventilation: bool = Field(alias="rearPassengerSeatVentilation")
     remote_econnect_capable: bool = Field(alias="remoteEConnectCapable")
@@ -89,7 +103,9 @@ class _ExtendedCapabilitiesModel(BaseModel):
     smart_key_status: bool = Field(alias="smartKeyStatus")
     steering_heater: bool = Field(alias="steeringHeater")
     stellantis_climate_capable: bool = Field(alias="stellantisClimateCapable")
-    stellantis_vehicle_status_capable: bool = Field(alias="stellantisVehicleStatusCapable")
+    stellantis_vehicle_status_capable: bool = Field(
+        alias="stellantisVehicleStatusCapable"
+    )
     sunroof: bool = Field(alias="sunroof")
     telemetry_capable: bool = Field(alias="telemetryCapable")
     trunk_lock_unlock_capable: bool = Field(alias="trunkLockUnlockCapable")
@@ -118,17 +134,25 @@ class _DcmModel(BaseModel):  # Data connection model
     supplier_name: str = Field(alias="dcmSupplierName")
     euicc_id: str = Field(alias="euiccid")
     hardware_type: Optional[str] = Field(alias="hardwareType")
-    vehicle_unit_terminal_number: Optional[str] = Field(alias="vehicleUnitTerminalNumber")
+    vehicle_unit_terminal_number: Optional[str] = Field(
+        alias="vehicleUnitTerminalNumber"
+    )
 
 
 class _HeadUnitModel(BaseModel):
-    description: Optional[Any] = Field(alias="huDescription")  # TODO unsure what this returns
-    generation: Optional[Any] = Field(alias="huGeneration")  # TODO unsure what this returns
+    description: Optional[Any] = Field(
+        alias="huDescription"
+    )  # TODO unsure what this returns
+    generation: Optional[Any] = Field(
+        alias="huGeneration"
+    )  # TODO unsure what this returns
     version: Optional[Any] = Field(alias="huVersion")  # TODO unsure what this returns
     mobile_platform_code: Optional[Any] = Field(
         alias="mobilePlatformCode"
     )  # TODO unsure what this returns
-    multimedia_type: Optional[Any] = Field(alias="multimediaType")  # TODO unsure what this returns
+    multimedia_type: Optional[Any] = Field(
+        alias="multimediaType"
+    )  # TODO unsure what this returns
 
 
 class _SubscriptionsModel(BaseModel):
@@ -365,21 +389,27 @@ class VehicleGuidModel(BaseModel):
     car_line_name: str = Field(alias="carlineName")
     color: str
     commercial_rental: bool = Field(alias="commercialRental")
-    contract_id: str = Field(alias="contractId")
+    contract_id: Optional[str] = Field(alias="contractId", default=None)
     cts_links: _LinksModel = Field(alias="ctsLinks")
-    data_consent: _DataConsentModel = Field(alias="dataConsent")
+    data_consent: Optional[_DataConsentModel] = Field(alias="dataConsent", default=None)
     date_of_first_use: Optional[date] = Field(alias="dateOfFirstUse")
     dcm: Optional[_DcmModel] = None
     dcm_active: bool = Field(alias="dcmActive")
     dcms: Optional[Any]  # TODO unsure what this returns
     display_model_description: str = Field(alias="displayModelDescription")
-    display_subscriptions: List[Dict[str, str]] = Field(alias="displaySubscriptions")
-    electrical_platform_code: Optional[str] = Field(alias="electricalPlatformCode", default=None)
+    display_subscriptions: Optional[List[Dict[str, str]]] = Field(
+        alias="displaySubscriptions", default=None
+    )
+    electrical_platform_code: Optional[str] = Field(
+        alias="electricalPlatformCode", default=None
+    )
     emergency_contact: Optional[Any] = Field(
         alias="emergencyContact"
     )  # TODO unsure what this returns
     ev_vehicle: bool = Field(alias="evVehicle")
-    extended_capabilities: _ExtendedCapabilitiesModel = Field(alias="extendedCapabilities")
+    extended_capabilities: _ExtendedCapabilitiesModel = Field(
+        alias="extendedCapabilities"
+    )
     external_subscriptions: Optional[Any] = Field(alias="externalSubscriptions")
     family_sharing: bool = Field(alias="familySharing")
     faq_url: str = Field(alias="faqUrl")
@@ -409,7 +439,9 @@ class VehicleGuidModel(BaseModel):
     primary_subscriber: bool = Field(alias="primarySubscriber")
     region: str
     registration_number: Optional[str] = Field(alias="registrationNumber")
-    remote_display: Optional[Any] = Field(alias="remoteDisplay")  # TODO unsure what this returns
+    remote_display: Optional[Any] = Field(
+        alias="remoteDisplay"
+    )  # TODO unsure what this returns
     remote_service_capabilities: _RemoteServiceCapabilitiesModel = Field(
         alias="remoteServiceCapabilities"
     )
@@ -417,20 +449,24 @@ class VehicleGuidModel(BaseModel):
         alias="remoteServicesExceptions"
     )  # TODO unsure what this returns
     remote_subscription_exists: bool = Field(alias="remoteSubscriptionExists")
-    remote_subscription_status: str = Field(alias="remoteSubscriptionStatus")
+    remote_subscription_status: Optional[str] = Field(
+        alias="remoteSubscriptionStatus", default=None
+    )
     remote_user: bool = Field(alias="remoteUser")
-    remote_user_guid: Optional[Union[UUID, str]] = Field(alias="remoteUserGuid", default=None)
+    remote_user_guid: Optional[Union[UUID, str]] = Field(
+        alias="remoteUserGuid", default=None
+    )
     service_connect_status: Optional[Any] = Field(
         alias="serviceConnectStatus"
     )  # TODO unsure what this returns
-    services: List[Any]  # TODO unsure what this returns
+    services: Optional[List[Any]] = None  # TODO unsure what this returns
     shop_genuine_parts_url: str = Field(alias="shopGenuinePartsUrl")
     status: str
     stock_pic_reference: str = Field(alias="stockPicReference")
-    subscriber_guid: UUID = Field(alias="subscriberGuid")
+    subscriber_guid: Optional[UUID] = Field(alias="subscriberGuid", default=None)
     subscription_expiration_status: bool = Field(alias="subscriptionExpirationStatus")
-    subscription_status: str = Field(alias="subscriptionStatus")
-    subscriptions: List[_SubscriptionsModel]
+    subscription_status: Optional[str] = Field(alias="subscriptionStatus", default=None)
+    subscriptions: Optional[List[_SubscriptionsModel]] = None
     suffix_code: Optional[Any] = Field(alias="suffixCode")
     svl_satus: bool = Field(alias="svlStatus")
     tff_links: _LinksModel = Field(alias="tffLinks")


### PR DESCRIPTION
Interestingly, there are probably vehicles / accounts where the endpoints did not even return basic information to the car.
See https://github.com/DurgNomis-drol/ha_toyota/issues/211