### PR TITLE
Bug: Remove stream entry from log_config.yaml

### DIFF
--- a/mytoyota/utils/logging/log_config.yaml
+++ b/mytoyota/utils/logging/log_config.yaml
@@ -10,7 +10,6 @@ handlers:
   stream:
     class: "logging.StreamHandler"
     formatter: "simple"
-    stream: sys.stdout
     filters:
       - "logfilter"
 


### PR DESCRIPTION
Remove `stream` settings from logging settings.

In the course of https://github.com/DurgNomis-drol/ha_toyota/discussions/218#discussioncomment-8225268 I had another look at the `log_config.yaml` and realised that the `stream` setting has no effect.

Rather, this currently causes an error when trying to log to a file. After deleting the `stream` setting, logging to a file works again. E.g with `python simple_client_example.py &> test.log`