### PR TITLE
Fix: TypeError: expected string or bytes-like object, got 'list'

### DIFF
--- a/mytoyota/utils/logging/log_filters.py
+++ b/mytoyota/utils/logging/log_filters.py
@@ -20,5 +20,5 @@ class RedactingFilter(logging.Filter):
         """Mask sensitive data in logs by given patterns."""
         for pattern in self._patterns:
             compiled_pattern = re.compile(pattern)
-            msg = compiled_pattern.sub("****", msg)
+            msg = compiled_pattern.sub("****", str(msg))
         return msg


### PR DESCRIPTION
`sub` expects a string for string masking, but currently it can receive any type. Therefore, we should convert the message into a string beforehand.

```log
2024-01-27T21:12:43.276792243Z   File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 256, in _async_update_data
2024-01-27T21:12:43.276804451Z     return await self.update_method()
2024-01-27T21:12:43.276813478Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-27T21:12:43.276821534Z   File "/config/custom_components/toyota/__init__.py", line 102, in async_get_vehicle_data
2024-01-27T21:12:43.276830029Z     _LOGGER.debug(vehicle_informations)
2024-01-27T21:12:43.276837955Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 1477, in debug
2024-01-27T21:12:43.276868291Z     self._log(DEBUG, msg, args, **kwargs)
2024-01-27T21:12:43.276877968Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 1634, in _log
2024-01-27T21:12:43.276890185Z     self.handle(record)
2024-01-27T21:12:43.276902704Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 1644, in handle
2024-01-27T21:12:43.276912209Z     self.callHandlers(record)
2024-01-27T21:12:43.276920238Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 1706, in callHandlers
2024-01-27T21:12:43.276929011Z     hdlr.handle(record)
2024-01-27T21:12:43.276937179Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 974, in handle
2024-01-27T21:12:43.276945496Z     rv = self.filter(record)
2024-01-27T21:12:43.276957643Z          ^^^^^^^^^^^^^^^^^^^
2024-01-27T21:12:43.276970582Z   File "/usr/local/lib/python3.11/logging/__init__.py", line 830, in filter
2024-01-27T21:12:43.276979936Z     result = f.filter(record)
2024-01-27T21:12:43.276987794Z              ^^^^^^^^^^^^^^^^
2024-01-27T21:12:43.276995922Z   File "/usr/local/lib/python3.11/site-packages/mytoyota/utils/logging/log_filters.py", line 16, in filter
2024-01-27T21:12:43.277008170Z     record.msg = self.mask_sensitive_data(record.msg)
2024-01-27T21:12:43.277020769Z                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-27T21:12:43.277030495Z   File "/usr/local/lib/python3.11/site-packages/mytoyota/utils/logging/log_filters.py", line 23, in mask_sensitive_data
2024-01-27T21:12:43.277039476Z     msg = compiled_pattern.sub("****", msg)
2024-01-27T21:12:43.277047483Z           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-01-27T21:12:43.277055417Z TypeError: expected string or bytes-like object, got 'list'
2024-01-27T21:12:43.277063292Z 2024-01-27 22:12:43 DEBUG Finished fetching toyota data in 1.984 seconds (success: False)
```