### PR TITLE
Fix: Make `ev_range`, `ev_range_with_ac` and `dcmSupplierName` optional

### DIFF
--- a/mytoyota/models/dashboard.py
+++ b/mytoyota/models/dashboard.py
@@ -126,7 +126,7 @@ class Dashboard:
             If vehicle doesn't support battery range returns None
 
         """
-        if self._electric:
+        if self._electric and self._electric.ev_range:
             return convert_distance(
                 self._distance_unit,
                 self._electric.ev_range.unit,
@@ -147,7 +147,7 @@ class Dashboard:
             If vehicle doesn't support battery range returns 0
 
         """
-        if self._electric:
+        if self._electric and self._electric.ev_range_with_ac:
             return convert_distance(
                 self._distance_unit,
                 self._electric.ev_range_with_ac.unit,

--- a/mytoyota/models/endpoints/electric.py
+++ b/mytoyota/models/endpoints/electric.py
@@ -30,8 +30,8 @@ class ElectricStatusModel(BaseModel):
         alias="canSetNextChargingEvent", default=None
     )
     charging_status: str = Field(alias="chargingStatus")
-    ev_range: UnitValueModel = Field(alias="evRange")
-    ev_range_with_ac: UnitValueModel = Field(alias="evRangeWithAc")
+    ev_range: Optional[UnitValueModel] = Field(alias="evRange")
+    ev_range_with_ac: Optional[UnitValueModel] = Field(alias="evRangeWithAc")
     fuel_level: Optional[int] = Field(alias="fuelLevel", default=None)
     fuel_range: Optional[UnitValueModel] = Field(alias="fuelRange", default=None)
     last_update_timestamp: datetime = Field(alias="lastUpdateTimestamp")

--- a/mytoyota/models/endpoints/vehicle_guid.py
+++ b/mytoyota/models/endpoints/vehicle_guid.py
@@ -115,7 +115,7 @@ class _DcmModel(BaseModel):  # Data connection model
     grade: str = Field(alias="dcmGrade")
     car_model_year: str = Field(alias="dcmModelYear")
     supplier: str = Field(alias="dcmSupplier")
-    supplier_name: str = Field(alias="dcmSupplierName")
+    supplier_name: Optional[str] = Field(alias="dcmSupplierName", default=None)
     euicc_id: str = Field(alias="euiccid")
     hardware_type: Optional[str] = Field(alias="hardwareType")
     vehicle_unit_terminal_number: Optional[str] = Field(alias="vehicleUnitTerminalNumber")


### PR DESCRIPTION
Seems there was another change in the toyota api which requires to make some fields in the `ElectricResponseModel` optional.
This should fix https://github.com/DurgNomis-drol/ha_toyota/issues/248