### PR TITLE
Use `CustomBaseModel` on all endpoint models and make fields `Optional`

### DIFF
--- a/mytoyota/models/endpoints/account.py
+++ b/mytoyota/models/endpoints/account.py
@@ -3,56 +3,59 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _TermsActivityModel(BaseModel):
-    time_stamp: datetime = Field(alias="timeStamp")
-    version: str
+class _TermsActivityModel(CustomBaseModel):
+    time_stamp: Optional[datetime] = Field(alias="timeStamp")
+    version: Optional[str]
 
 
-class _AdditionalAttributesModel(BaseModel):
-    is_terms_accepted: bool = Field(alias="isTermsAccepted")
-    terms_activity: List[_TermsActivityModel] = Field("termsActivity")
+class _AdditionalAttributesModel(CustomBaseModel):
+    is_terms_accepted: Optional[bool] = Field(alias="isTermsAccepted")
+    terms_activity: Optional[List[_TermsActivityModel]] = Field("termsActivity")
 
 
-class _EmailModel(BaseModel):
-    email_address: str = Field(alias="emailAddress")
-    email_type: str = Field(alias="emailType")
-    email_verified: bool = Field(alias="emailVerified")
-    verification_date: datetime = Field(alias="verificationDate")
+class _EmailModel(CustomBaseModel):
+    email_address: Optional[str] = Field(alias="emailAddress")
+    email_type: Optional[str] = Field(alias="emailType")
+    email_verified: Optional[bool] = Field(alias="emailVerified")
+    verification_date: Optional[datetime] = Field(alias="verificationDate")
 
 
-class _PhoneNumberModel(BaseModel):
-    country_code: int = Field(alias="countryCode")
-    phone_number: int = Field(alias="phoneNumber")
-    phone_verified: bool = Field(alias="phoneVerified")
-    verification_date: datetime = Field("verificationDate")
+class _PhoneNumberModel(CustomBaseModel):
+    country_code: Optional[int] = Field(alias="countryCode")
+    phone_number: Optional[int] = Field(alias="phoneNumber")
+    phone_verified: Optional[bool] = Field(alias="phoneVerified")
+    verification_date: Optional[datetime] = Field("verificationDate")
 
 
-class _CustomerModel(BaseModel):
-    account_status: str = Field(alias="accountStatus")
-    additional_attributes: _AdditionalAttributesModel = Field(alias="additionalAttributes")
-    create_date: datetime = Field(alias="createDate")
-    create_source: str = Field(alias="createSource")
-    customer_type: str = Field(alias="customerType")
-    emails: List[_EmailModel]
-    first_name: str = Field(alias="firstName")
-    forge_rock_id: UUID = Field(alias="forgerockId")
-    guid: UUID
-    is_cp_migrated: bool = Field(alias="isCpMigrated")
-    lastname: str = Field(alias="lastName")
-    last_update_date: datetime = Field("lastUpdateDate")
-    last_update_source: str = Field("lastUpdateSource")
-    phone_numbers: List[_PhoneNumberModel] = Field(alias="phoneNumbers")
-    preferred_language: str = Field(alias="preferredLanguage")
-    signup_type: str = Field(alias="signupType")
-    ui_language: str = Field(alias="uiLanguage")
+class _CustomerModel(CustomBaseModel):
+    account_status: Optional[str] = Field(alias="accountStatus")
+    additional_attributes: Optional[_AdditionalAttributesModel] = Field(
+        alias="additionalAttributes"
+    )
+    create_date: Optional[datetime] = Field(alias="createDate")
+    create_source: Optional[str] = Field(alias="createSource")
+    customer_type: Optional[str] = Field(alias="customerType")
+    emails: Optional[List[_EmailModel]]
+    first_name: Optional[str] = Field(alias="firstName")
+    forge_rock_id: Optional[UUID] = Field(alias="forgerockId")
+    guid: Optional[UUID]
+    is_cp_migrated: Optional[bool] = Field(alias="isCpMigrated")
+    lastname: Optional[str] = Field(alias="lastName")
+    last_update_date: Optional[datetime] = Field("lastUpdateDate")
+    last_update_source: Optional[str] = Field("lastUpdateSource")
+    phone_numbers: Optional[List[_PhoneNumberModel]] = Field(alias="phoneNumbers")
+    preferred_language: Optional[str] = Field(alias="preferredLanguage")
+    signup_type: Optional[str] = Field(alias="signupType")
+    ui_language: Optional[str] = Field(alias="uiLanguage")
 
 
-class AccountModel(BaseModel):
+class AccountModel(CustomBaseModel):
     """Model representing an account.
 
     Attributes
@@ -61,7 +64,7 @@ class AccountModel(BaseModel):
 
     """
 
-    customer: _CustomerModel
+    customer: Optional[_CustomerModel]
 
 
 class AccountResponseModel(StatusModel):

--- a/mytoyota/models/endpoints/common.py
+++ b/mytoyota/models/endpoints/common.py
@@ -1,10 +1,12 @@
 """Toyota Connected Services API - Common Endpoint Models."""
 from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from mytoyota.utils.models import CustomBaseModel
 
 
-class UnitValueModel(BaseModel):
+class UnitValueModel(CustomBaseModel):
     """Model representing a unit and a value.
 
     Can be reused several times within other models.
@@ -20,17 +22,17 @@ class UnitValueModel(BaseModel):
     value: Optional[float] = None
 
 
-class _MessageModel(BaseModel):
-    description: str
+class _MessageModel(CustomBaseModel):
+    description: Optional[str]
     detailed_description: Optional[str] = Field(alias="detailedDescription", default=None)
-    response_code: str = Field(alias="responseCode")
+    response_code: Optional[str] = Field(alias="responseCode")
 
 
-class _MessagesModel(BaseModel):
-    messages: List[_MessageModel]
+class _MessagesModel(CustomBaseModel):
+    messages: Optional[List[_MessageModel]]
 
 
-class StatusModel(BaseModel):
+class StatusModel(CustomBaseModel):
     """Model representing the status of an endpoint.
 
     Attributes
@@ -43,7 +45,7 @@ class StatusModel(BaseModel):
 
     """
 
-    status: Union[str, _MessagesModel]
+    status: Optional[Union[str, _MessagesModel]]
     code: Optional[int] = None
-    errors: Optional[List] = []
+    errors: Optional[List] = None
     message: Optional[str] = None

--- a/mytoyota/models/endpoints/electric.py
+++ b/mytoyota/models/endpoints/electric.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel, UnitValueModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class ElectricStatusModel(BaseModel):
+class ElectricStatusModel(CustomBaseModel):
     r"""Model representing the status of an electric vehicle.
 
     Attributes
@@ -25,16 +26,16 @@ class ElectricStatusModel(BaseModel):
 
     """
 
-    battery_level: int = Field(alias="batteryLevel")
+    battery_level: Optional[int] = Field(alias="batteryLevel")
     can_set_next_charging_event: Optional[bool] = Field(
         alias="canSetNextChargingEvent", default=None
     )
-    charging_status: str = Field(alias="chargingStatus")
+    charging_status: Optional[str] = Field(alias="chargingStatus")
     ev_range: Optional[UnitValueModel] = Field(alias="evRange")
     ev_range_with_ac: Optional[UnitValueModel] = Field(alias="evRangeWithAc")
     fuel_level: Optional[int] = Field(alias="fuelLevel", default=None)
     fuel_range: Optional[UnitValueModel] = Field(alias="fuelRange", default=None)
-    last_update_timestamp: datetime = Field(alias="lastUpdateTimestamp")
+    last_update_timestamp: Optional[datetime] = Field(alias="lastUpdateTimestamp")
     remaining_charge_time: Optional[int] = Field(
         alias="remainingChargeTime",
         default=None,

--- a/mytoyota/models/endpoints/location.py
+++ b/mytoyota/models/endpoints/location.py
@@ -2,19 +2,20 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _VehicleLocationModel(BaseModel):
-    display_name: str = Field(alias="displayName")
-    latitude: float
-    location_acquisition_datetime: datetime = Field(alias="locationAcquisitionDatetime")
-    longitude: float
+class _VehicleLocationModel(CustomBaseModel):
+    display_name: Optional[str] = Field(alias="displayName")
+    latitude: Optional[float]
+    location_acquisition_datetime: Optional[datetime] = Field(alias="locationAcquisitionDatetime")
+    longitude: Optional[float]
 
 
-class LocationModel(BaseModel):
+class LocationModel(CustomBaseModel):
     r"""Model representing the location of a vehicle.
 
     Attributes

--- a/mytoyota/models/endpoints/notifications.py
+++ b/mytoyota/models/endpoints/notifications.py
@@ -3,14 +3,16 @@ from datetime import datetime
 from typing import List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _HeadersModel(BaseModel):
-    content_type: str = Field(..., alias="Content-Type")
+class _HeadersModel(CustomBaseModel):
+    content_type: Optional[str] = Field(..., alias="Content-Type")
 
 
-class NotificationModel(BaseModel):
+class NotificationModel(CustomBaseModel):
     """Model representing a notification.
 
     Attributes
@@ -29,25 +31,25 @@ class NotificationModel(BaseModel):
 
     """
 
-    message_id: str = Field(alias="messageId")
-    vin: str
-    notification_date: datetime = Field(alias="notificationDate")
-    is_read: bool = Field(alias="isRead")
+    message_id: Optional[str] = Field(alias="messageId")
+    vin: Optional[str]
+    notification_date: Optional[datetime] = Field(alias="notificationDate")
+    is_read: Optional[bool] = Field(alias="isRead")
     read_timestamp: Optional[datetime] = Field(alias="readTimestamp", default=None)
-    icon_url: str = Field(alias="iconUrl")
-    message: str
+    icon_url: Optional[str] = Field(alias="iconUrl")
+    message: Optional[str]
     status: Optional[Union[int, str]] = None
-    type: str
-    category: str
-    display_category: str = Field(alias="displayCategory")
+    type: Optional[str]
+    category: Optional[str]
+    display_category: Optional[str] = Field(alias="displayCategory")
 
 
-class _PayloadItemModel(BaseModel):
-    vin: str = None
-    notifications: List[NotificationModel]
+class _PayloadItemModel(CustomBaseModel):
+    vin: Optional[str] = None
+    notifications: Optional[List[NotificationModel]]
 
 
-class NotificationResponseModel(BaseModel):
+class NotificationResponseModel(CustomBaseModel):
     r"""Model representing a notification response.
 
     Attributes
@@ -61,8 +63,8 @@ class NotificationResponseModel(BaseModel):
 
     """
 
-    guid: UUID = None
-    status_code: int = Field(alias="statusCode")
-    headers: _HeadersModel
-    body: str
+    guid: Optional[UUID] = None
+    status_code: Optional[int] = Field(alias="statusCode")
+    headers: Optional[_HeadersModel]
+    body: Optional[str]
     payload: Optional[List[_PayloadItemModel]] = None

--- a/mytoyota/models/endpoints/service_history.py
+++ b/mytoyota/models/endpoints/service_history.py
@@ -3,12 +3,13 @@
 from datetime import date
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class ServiceHistoryModel(BaseModel):
+class ServiceHistoryModel(CustomBaseModel):
     """Represents a service history record.
 
     Attributes
@@ -27,20 +28,20 @@ class ServiceHistoryModel(BaseModel):
 
     """
 
-    customer_created_record: bool = Field(alias="customerCreatedRecord")
+    customer_created_record: Optional[bool] = Field(alias="customerCreatedRecord")
     mileage: Optional[int] = None
     notes: Any
     operations_performed: Any = Field(alias="operationsPerformed")
     ro_number: Any = Field(alias="roNumber")
-    service_category: str = Field(alias="serviceCategory")
-    service_date: date = Field(alias="serviceDate")
-    service_history_id: str = Field(alias="serviceHistoryId")
-    service_provider: str = Field(alias="serviceProvider")
+    service_category: Optional[str] = Field(alias="serviceCategory")
+    service_date: Optional[date] = Field(alias="serviceDate")
+    service_history_id: Optional[str] = Field(alias="serviceHistoryId")
+    service_provider: Optional[str] = Field(alias="serviceProvider")
     servicing_dealer: Any = Field(alias="servicingDealer")
     unit: Optional[str] = None
 
 
-class ServiceHistoriesModel(BaseModel):
+class ServiceHistoriesModel(CustomBaseModel):
     r"""Model representing a list of service histories.
 
     Attributes
@@ -50,7 +51,7 @@ class ServiceHistoriesModel(BaseModel):
 
     """
 
-    service_histories: List[Optional[ServiceHistoryModel]] = Field(
+    service_histories: Optional[List[Optional[ServiceHistoryModel]]] = Field(
         alias="serviceHistories", default=[]
     )
 

--- a/mytoyota/models/endpoints/status.py
+++ b/mytoyota/models/endpoints/status.py
@@ -2,17 +2,18 @@
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel, UnitValueModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _ValueStatusModel(BaseModel):
-    value: str
-    status: int
+class _ValueStatusModel(CustomBaseModel):
+    value: Optional[str]
+    status: Optional[int]
 
 
-class SectionModel(BaseModel):
+class SectionModel(CustomBaseModel):
     """Model representing the status category of a vehicle.
 
     Attributes
@@ -22,11 +23,11 @@ class SectionModel(BaseModel):
 
     """
 
-    section: str
-    values: List[_ValueStatusModel]
+    section: Optional[str]
+    values: Optional[List[_ValueStatusModel]]
 
 
-class VehicleStatusModel(BaseModel):
+class VehicleStatusModel(CustomBaseModel):
     """Model representing the status category of a vehicle.
 
     Attributes
@@ -38,18 +39,18 @@ class VehicleStatusModel(BaseModel):
 
     """
 
-    category: str
-    display_order: int = Field(alias="displayOrder")
-    sections: List[SectionModel]
+    category: Optional[str]
+    display_order: Optional[int] = Field(alias="displayOrder")
+    sections: Optional[List[SectionModel]]
 
 
-class _TelemetryModel(BaseModel):
+class _TelemetryModel(CustomBaseModel):
     fugage: Optional[UnitValueModel] = None
     rage: Optional[UnitValueModel] = None
-    odo: UnitValueModel
+    odo: Optional[UnitValueModel]
 
 
-class RemoteStatusModel(BaseModel):
+class RemoteStatusModel(CustomBaseModel):
     """Model representing the remote status of a vehicle.
 
     Attributes
@@ -64,13 +65,13 @@ class RemoteStatusModel(BaseModel):
 
     """
 
-    vehicle_status: List[VehicleStatusModel] = Field(alias="vehicleStatus")
-    telemetry: _TelemetryModel
-    occurrence_date: datetime = Field(alias="occurrenceDate")
-    caution_overall_count: int = Field(alias="cautionOverallCount")
-    latitude: float
-    longitude: float
-    location_acquisition_datetime: datetime = Field(alias="locationAcquisitionDatetime")
+    vehicle_status: Optional[List[VehicleStatusModel]] = Field(alias="vehicleStatus")
+    telemetry: Optional[_TelemetryModel]
+    occurrence_date: Optional[datetime] = Field(alias="occurrenceDate")
+    caution_overall_count: Optional[int] = Field(alias="cautionOverallCount")
+    latitude: Optional[float]
+    longitude: Optional[float]
+    location_acquisition_datetime: Optional[datetime] = Field(alias="locationAcquisitionDatetime")
 
 
 class RemoteStatusResponseModel(StatusModel):

--- a/mytoyota/models/endpoints/telemetry.py
+++ b/mytoyota/models/endpoints/telemetry.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel, UnitValueModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class TelemetryModel(BaseModel):
+class TelemetryModel(CustomBaseModel):
     r"""Model representing telemetry data.
 
     Attributes
@@ -21,11 +22,11 @@ class TelemetryModel(BaseModel):
 
     """
 
-    fuel_type: str = Field(alias="fuelType")
-    odometer: UnitValueModel
+    fuel_type: Optional[str] = Field(alias="fuelType")
+    odometer: Optional[UnitValueModel]
     fuel_level: Optional[int] = Field(alias="fuelLevel", default=None)
     distance_to_empty: Optional[UnitValueModel] = Field(alias="distanceToEmpty", default=None)
-    timestamp: datetime
+    timestamp: Optional[datetime]
 
 
 class TelemetryResponseModel(StatusModel):

--- a/mytoyota/models/endpoints/trips.py
+++ b/mytoyota/models/endpoints/trips.py
@@ -5,23 +5,24 @@ from datetime import date, datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
 from mytoyota.utils.helpers import add_with_none
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _SummaryBaseModel(BaseModel):
-    length: int
-    duration: int
-    duration_idle: int = Field(alias="durationIdle")
-    countries: List[str]
-    max_speed: float = Field(alias="maxSpeed")
-    average_speed: float = Field(alias="averageSpeed")
-    length_overspeed: int = Field(alias="lengthOverspeed")
-    duration_overspeed: int = Field(alias="durationOverspeed")
-    length_highway: int = Field(alias="lengthHighway")
-    duration_highway: int = Field(alias="durationHighway")
+class _SummaryBaseModel(CustomBaseModel):
+    length: Optional[int]
+    duration: Optional[int]
+    duration_idle: Optional[int] = Field(alias="durationIdle")
+    countries: Optional[List[str]]
+    max_speed: Optional[float] = Field(alias="maxSpeed")
+    average_speed: Optional[float] = Field(alias="averageSpeed")
+    length_overspeed: Optional[int] = Field(alias="lengthOverspeed")
+    duration_overspeed: Optional[int] = Field(alias="durationOverspeed")
+    length_highway: Optional[int] = Field(alias="lengthHighway")
+    duration_highway: Optional[int] = Field(alias="durationHighway")
     fuel_consumption: Optional[float] = Field(
         alias="fuelConsumption", default=None
     )  # Electric cars might not use fuel. Milliliters.
@@ -53,38 +54,38 @@ class _SummaryBaseModel(BaseModel):
 
 
 class _SummaryModel(_SummaryBaseModel):
-    start_lat: float = Field(alias="startLat")
-    start_lon: float = Field(alias="startLon")
-    start_ts: datetime = Field(alias="startTs")
-    end_lat: float = Field(alias="endLat")
-    end_lon: float = Field(alias="endLon")
-    end_ts: datetime = Field(alias="endTs")
-    night_trip: bool = Field(alias="nightTrip")
+    start_lat: Optional[float] = Field(alias="startLat")
+    start_lon: Optional[float] = Field(alias="startLon")
+    start_ts: Optional[datetime] = Field(alias="startTs")
+    end_lat: Optional[float] = Field(alias="endLat")
+    end_lon: Optional[float] = Field(alias="endLon")
+    end_ts: Optional[datetime] = Field(alias="endTs")
+    night_trip: Optional[bool] = Field(alias="nightTrip")
 
 
-class _CoachingMsgParamModel(BaseModel):
-    name: str
-    unit: str
-    value: int
+class _CoachingMsgParamModel(CustomBaseModel):
+    name: Optional[str]
+    unit: Optional[str]
+    value: Optional[int]
 
 
-class _BehaviourModel(BaseModel):
-    ts: datetime
+class _BehaviourModel(CustomBaseModel):
+    ts: Optional[datetime]
     type: Optional[str] = None
     coaching_msg_params: Optional[List[_CoachingMsgParamModel]] = Field(
         alias="coachingMsgParams", default=None
     )
 
 
-class _ScoresModel(BaseModel):
-    global_: int = Field(..., alias="global")
+class _ScoresModel(CustomBaseModel):
+    global_: Optional[int] = Field(..., alias="global")
     acceleration: Optional[int] = None
     braking: Optional[int] = None
     advice: Optional[int] = None
     constant_speed: Optional[int] = Field(alias="constantSpeed", default=None)
 
 
-class _HDCModel(BaseModel):
+class _HDCModel(CustomBaseModel):
     ev_time: Optional[int] = Field(alias="evTime", default=None)
     ev_distance: Optional[int] = Field(alias="evDistance", default=None)
     charge_time: Optional[int] = Field(alias="chargeTime", default=None)
@@ -117,65 +118,65 @@ class _HDCModel(BaseModel):
         return self
 
 
-class _RouteModel(BaseModel):
-    lat: float = Field(repr=False)
-    lon: float
-    overspeed: bool
-    highway: bool
-    index_in_points: int = Field(alias="indexInPoints")
+class _RouteModel(CustomBaseModel):
+    lat: Optional[float] = Field(repr=False)
+    lon: Optional[float]
+    overspeed: Optional[bool]
+    highway: Optional[bool]
+    index_in_points: Optional[int] = Field(alias="indexInPoints")
     mode: Optional[int] = None
-    is_ev: bool = Field(alias="isEv")
+    is_ev: Optional[bool] = Field(alias="isEv")
 
 
-class _TripModel(BaseModel):
-    id: UUID
-    category: int
-    summary: _SummaryModel
+class _TripModel(CustomBaseModel):
+    id: Optional[UUID]
+    category: Optional[int]
+    summary: Optional[_SummaryModel]
     scores: Optional[_ScoresModel] = None
     behaviours: Optional[List[_BehaviourModel]] = None
     hdc: Optional[_HDCModel] = None
     route: Optional[List[_RouteModel]] = None
 
 
-class _HistogramModel(BaseModel):
-    year: int
-    month: int
-    day: int
-    summary: _SummaryBaseModel
+class _HistogramModel(CustomBaseModel):
+    year: Optional[int]
+    month: Optional[int]
+    day: Optional[int]
+    summary: Optional[_SummaryBaseModel]
     scores: Optional[_ScoresModel] = None
     hdc: Optional[_HDCModel] = None
 
 
-class _SummaryItemModel(BaseModel):
-    year: int
-    month: int
-    summary: _SummaryBaseModel
+class _SummaryItemModel(CustomBaseModel):
+    year: Optional[int]
+    month: Optional[int]
+    summary: Optional[_SummaryBaseModel]
     scores: Optional[_ScoresModel] = None
     hdc: Optional[_HDCModel] = None
     histograms: List[_HistogramModel]
 
 
-class _PaginationModel(BaseModel):
-    limit: int
-    offset: int
+class _PaginationModel(CustomBaseModel):
+    limit: Optional[int]
+    offset: Optional[int]
     previous_offset: Optional[Any] = Field(alias="previousOffset", default=None)
     next_offset: Optional[int] = Field(alias="nextOffset", default=None)
-    current_page: int = Field(alias="currentPage")
-    total_count: int = Field(alias="totalCount")
-    page_count: int = Field(alias="pageCount")
+    current_page: Optional[int] = Field(alias="currentPage")
+    total_count: Optional[int] = Field(alias="totalCount")
+    page_count: Optional[int] = Field(alias="pageCount")
 
 
-class _SortedByItemModel(BaseModel):
-    field: str
-    order: str
+class _SortedByItemModel(CustomBaseModel):
+    field: Optional[str]
+    order: Optional[str]
 
 
-class _MetadataModel(BaseModel):
-    pagination: _PaginationModel
-    sorted_by: List[_SortedByItemModel] = Field(alias="sortedBy")
+class _MetadataModel(CustomBaseModel):
+    pagination: Optional[_PaginationModel]
+    sorted_by: Optional[List[_SortedByItemModel]] = Field(alias="sortedBy")
 
 
-class TripsModel(BaseModel):
+class TripsModel(CustomBaseModel):
     r"""Model representing trips data.
 
     Attributes
@@ -191,11 +192,11 @@ class TripsModel(BaseModel):
 
     """
 
-    from_date: date = Field(..., alias="from")
-    to_date: date = Field(..., alias="to")
-    trips: List[_TripModel]
+    from_date: Optional[date] = Field(..., alias="from")
+    to_date: Optional[date] = Field(..., alias="to")
+    trips: Optional[List[_TripModel]]
     summary: Optional[List[_SummaryItemModel]] = None
-    metadata: _MetadataModel = Field(..., alias="_metadata")
+    metadata: Optional[_MetadataModel] = Field(..., alias="_metadata")
     route: Optional[_RouteModel] = None
 
 

--- a/mytoyota/models/endpoints/vehicle_guid.py
+++ b/mytoyota/models/endpoints/vehicle_guid.py
@@ -3,105 +3,114 @@ from datetime import date
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class _TranslationModel(BaseModel):
+class _TranslationModel(CustomBaseModel):
     english: Optional[Any]  # TODO unsure what this returns
     french: Optional[Any]  # TODO unsure what this returns
     spanish: Optional[Any]  # TODO unsure what this returns
 
 
-class _CapabilitiesModel(BaseModel):
+class _CapabilitiesModel(CustomBaseModel):
     description: Optional[str]
-    display: bool
+    display: Optional[bool]
     display_name: Optional[Any] = Field(alias="displayName")  # TODO unsure what this returns
-    name: str
-    translation: _TranslationModel
+    name: Optional[str]
+    translation: Optional[_TranslationModel]
 
 
-class _ExtendedCapabilitiesModel(BaseModel):
-    c_scheduling: bool = Field(alias="acScheduling")
-    battery_status: bool = Field(alias="batteryStatus")
-    bonnet_status: bool = Field(alias="bonnetStatus")
-    bump_collisions: bool = Field(alias="bumpCollisions")
-    buzzer_capable: bool = Field(alias="buzzerCapable")
-    charge_management: bool = Field(alias="chargeManagement")
-    climate_capable: bool = Field(alias="climateCapable")
-    climate_temperature_control_full: bool = Field(alias="climateTemperatureControlFull")
-    climate_temperature_control_limited: bool = Field(alias="climateTemperatureControlLimited")
-    dashboard_warning_lights: bool = Field(alias="dashboardWarningLights")
-    door_lock_unlock_capable: bool = Field(alias="doorLockUnlockCapable")
-    drive_pulse: bool = Field(alias="drivePulse")
-    ecare: bool = Field(alias="ecare")
-    econnect_climate_capable: bool = Field(alias="econnectClimateCapable")
-    econnect_vehicle_status_capable: bool = Field(alias="econnectVehicleStatusCapable")
-    electric_pulse: bool = Field(alias="electricPulse")
-    emergency_assist: bool = Field(alias="emergencyAssist")
-    enhanced_security_system_capable: bool = Field(alias="enhancedSecuritySystemCapable")
-    equipped_with_alarm: bool = Field(alias="equippedWithAlarm")
-    ev_battery: bool = Field(alias="evBattery")
-    ev_charge_stations_capable: bool = Field(alias="evChargeStationsCapable")
-    fcv_stations_capable: bool = Field(alias="fcvStationsCapable")
-    front_defogger: bool = Field(alias="frontDefogger")
-    front_driver_door_lock_status: bool = Field(alias="frontDriverDoorLockStatus")
-    front_driver_door_open_status: bool = Field(alias="frontDriverDoorOpenStatus")
-    front_driver_door_window_status: bool = Field(alias="frontDriverDoorWindowStatus")
-    front_driver_seat_heater: bool = Field(alias="frontDriverSeatHeater")
-    front_driver_seat_ventilation: bool = Field(alias="frontDriverSeatVentilation")
-    front_passenger_door_lock_status: bool = Field(alias="frontPassengerDoorLockStatus")
-    front_passenger_door_open_status: bool = Field(alias="frontPassengerDoorOpenStatus")
-    front_passenger_door_window_status: bool = Field(alias="frontPassengerDoorWindowStatus")
-    front_passenger_seat_heater: bool = Field(alias="frontPassengerSeatHeater")
-    front_passenger_seat_ventilation: bool = Field(alias="frontPassengerSeatVentilation")
-    fuel_level_available: bool = Field(alias="fuelLevelAvailable")
-    fuel_range_available: bool = Field(alias="fuelRangeAvailable")
-    guest_driver: bool = Field(alias="guestDriver")
-    hazard_capable: bool = Field(alias="hazardCapable")
-    horn_capable: bool = Field(alias="hornCapable")
-    hybrid_pulse: bool = Field(alias="hybridPulse")
-    hydrogen_pulse: bool = Field(alias="hydrogenPulse")
-    last_parked_capable: bool = Field(alias="lastParkedCapable")
-    light_status: bool = Field(alias="lightStatus")
-    lights_capable: bool = Field(alias="lightsCapable")
-    manual_rear_windows: bool = Field(alias="manualRearWindows")
-    mirror_heater: bool = Field(alias="mirrorHeater")
-    moonroof: bool = Field(alias="moonroof")
-    next_charge: bool = Field(alias="nextCharge")
-    power_tailgate_capable: bool = Field(alias="powerTailgateCapable")
-    power_windows_capable: bool = Field(alias="powerWindowsCapable")
-    rear_defogger: bool = Field(alias="rearDefogger")
-    rear_driver_door_lock_status: bool = Field(alias="rearDriverDoorLockStatus")
-    rear_driver_door_open_status: bool = Field(alias="rearDriverDoorOpenStatus")
-    rear_driver_door_window_status: bool = Field(alias="rearDriverDoorWindowStatus")
-    rear_driver_seat_heater: bool = Field(alias="rearDriverSeatHeater")
-    rear_driver_seat_ventilation: bool = Field(alias="rearDriverSeatVentilation")
-    rear_hatch_rear_window: bool = Field(alias="rearHatchRearWindow")
-    rear_passenger_door_lock_status: bool = Field(alias="rearPassengerDoorLockStatus")
-    rear_passenger_door_open_status: bool = Field(alias="rearPassengerDoorOpenStatus")
-    rear_passenger_door_window_status: bool = Field(alias="rearPassengerDoorWindowStatus")
-    rear_passenger_seat_heater: bool = Field(alias="rearPassengerSeatHeater")
-    rear_passenger_seat_ventilation: bool = Field(alias="rearPassengerSeatVentilation")
-    remote_econnect_capable: bool = Field(alias="remoteEConnectCapable")
-    remote_engine_start_stop: bool = Field(alias="remoteEngineStartStop")
-    smart_key_status: bool = Field(alias="smartKeyStatus")
-    steering_heater: bool = Field(alias="steeringHeater")
-    stellantis_climate_capable: bool = Field(alias="stellantisClimateCapable")
-    stellantis_vehicle_status_capable: bool = Field(alias="stellantisVehicleStatusCapable")
-    sunroof: bool = Field(alias="sunroof")
-    telemetry_capable: bool = Field(alias="telemetryCapable")
-    trunk_lock_unlock_capable: bool = Field(alias="trunkLockUnlockCapable")
-    try_and_play: bool = Field(alias="tryAndPlay")
-    vehicle_diagnostic_capable: bool = Field(alias="vehicleDiagnosticCapable")
-    vehicle_finder: bool = Field(alias="vehicleFinder")
-    vehicle_status: bool = Field(alias="vehicleStatus")
-    we_hybrid_capable: bool = Field(alias="weHybridCapable")
-    weekly_charge: bool = Field(alias="weeklyCharge")
+class _ExtendedCapabilitiesModel(CustomBaseModel):
+    c_scheduling: Optional[bool] = Field(alias="acScheduling")
+    battery_status: Optional[bool] = Field(alias="batteryStatus")
+    bonnet_status: Optional[bool] = Field(alias="bonnetStatus")
+    bump_collisions: Optional[bool] = Field(alias="bumpCollisions")
+    buzzer_capable: Optional[bool] = Field(alias="buzzerCapable")
+    charge_management: Optional[bool] = Field(alias="chargeManagement")
+    climate_capable: Optional[bool] = Field(alias="climateCapable")
+    climate_temperature_control_full: Optional[bool] = Field(alias="climateTemperatureControlFull")
+    climate_temperature_control_limited: Optional[bool] = Field(
+        alias="climateTemperatureControlLimited"
+    )
+    dashboard_warning_lights: Optional[bool] = Field(alias="dashboardWarningLights")
+    door_lock_unlock_capable: Optional[bool] = Field(alias="doorLockUnlockCapable")
+    drive_pulse: Optional[bool] = Field(alias="drivePulse")
+    ecare: Optional[bool] = Field(alias="ecare")
+    econnect_climate_capable: Optional[bool] = Field(alias="econnectClimateCapable")
+    econnect_vehicle_status_capable: Optional[bool] = Field(alias="econnectVehicleStatusCapable")
+    electric_pulse: Optional[bool] = Field(alias="electricPulse")
+    emergency_assist: Optional[bool] = Field(alias="emergencyAssist")
+    enhanced_security_system_capable: Optional[bool] = Field(alias="enhancedSecuritySystemCapable")
+    equipped_with_alarm: Optional[bool] = Field(alias="equippedWithAlarm")
+    ev_battery: Optional[bool] = Field(alias="evBattery")
+    ev_charge_stations_capable: Optional[bool] = Field(alias="evChargeStationsCapable")
+    fcv_stations_capable: Optional[bool] = Field(alias="fcvStationsCapable")
+    front_defogger: Optional[bool] = Field(alias="frontDefogger")
+    front_driver_door_lock_status: Optional[bool] = Field(alias="frontDriverDoorLockStatus")
+    front_driver_door_open_status: Optional[bool] = Field(alias="frontDriverDoorOpenStatus")
+    front_driver_door_window_status: Optional[bool] = Field(alias="frontDriverDoorWindowStatus")
+    front_driver_seat_heater: Optional[bool] = Field(alias="frontDriverSeatHeater")
+    front_driver_seat_ventilation: Optional[bool] = Field(alias="frontDriverSeatVentilation")
+    front_passenger_door_lock_status: Optional[bool] = Field(alias="frontPassengerDoorLockStatus")
+    front_passenger_door_open_status: Optional[bool] = Field(alias="frontPassengerDoorOpenStatus")
+    front_passenger_door_window_status: Optional[bool] = Field(
+        alias="frontPassengerDoorWindowStatus"
+    )
+    front_passenger_seat_heater: Optional[bool] = Field(alias="frontPassengerSeatHeater")
+    front_passenger_seat_ventilation: Optional[bool] = Field(alias="frontPassengerSeatVentilation")
+    fuel_level_available: Optional[bool] = Field(alias="fuelLevelAvailable")
+    fuel_range_available: Optional[bool] = Field(alias="fuelRangeAvailable")
+    guest_driver: Optional[bool] = Field(alias="guestDriver")
+    hazard_capable: Optional[bool] = Field(alias="hazardCapable")
+    horn_capable: Optional[bool] = Field(alias="hornCapable")
+    hybrid_pulse: Optional[bool] = Field(alias="hybridPulse")
+    hydrogen_pulse: Optional[bool] = Field(alias="hydrogenPulse")
+    last_parked_capable: Optional[bool] = Field(alias="lastParkedCapable")
+    light_status: Optional[bool] = Field(alias="lightStatus")
+    lights_capable: Optional[bool] = Field(alias="lightsCapable")
+    manual_rear_windows: Optional[bool] = Field(alias="manualRearWindows")
+    mirror_heater: Optional[bool] = Field(alias="mirrorHeater")
+    moonroof: Optional[bool] = Field(alias="moonroof")
+    next_charge: Optional[bool] = Field(alias="nextCharge")
+    power_tailgate_capable: Optional[bool] = Field(alias="powerTailgateCapable")
+    power_windows_capable: Optional[bool] = Field(alias="powerWindowsCapable")
+    rear_defogger: Optional[bool] = Field(alias="rearDefogger")
+    rear_driver_door_lock_status: Optional[bool] = Field(alias="rearDriverDoorLockStatus")
+    rear_driver_door_open_status: Optional[bool] = Field(alias="rearDriverDoorOpenStatus")
+    rear_driver_door_window_status: Optional[bool] = Field(alias="rearDriverDoorWindowStatus")
+    rear_driver_seat_heater: Optional[bool] = Field(alias="rearDriverSeatHeater")
+    rear_driver_seat_ventilation: Optional[bool] = Field(alias="rearDriverSeatVentilation")
+    rear_hatch_rear_window: Optional[bool] = Field(alias="rearHatchRearWindow")
+    rear_passenger_door_lock_status: Optional[bool] = Field(alias="rearPassengerDoorLockStatus")
+    rear_passenger_door_open_status: Optional[bool] = Field(alias="rearPassengerDoorOpenStatus")
+    rear_passenger_door_window_status: Optional[bool] = Field(
+        alias="rearPassengerDoorWindowStatus"
+    )
+    rear_passenger_seat_heater: Optional[bool] = Field(alias="rearPassengerSeatHeater")
+    rear_passenger_seat_ventilation: Optional[bool] = Field(alias="rearPassengerSeatVentilation")
+    remote_econnect_capable: Optional[bool] = Field(alias="remoteEConnectCapable")
+    remote_engine_start_stop: Optional[bool] = Field(alias="remoteEngineStartStop")
+    smart_key_status: Optional[bool] = Field(alias="smartKeyStatus")
+    steering_heater: Optional[bool] = Field(alias="steeringHeater")
+    stellantis_climate_capable: Optional[bool] = Field(alias="stellantisClimateCapable")
+    stellantis_vehicle_status_capable: Optional[bool] = Field(
+        alias="stellantisVehicleStatusCapable"
+    )
+    sunroof: Optional[bool] = Field(alias="sunroof")
+    telemetry_capable: Optional[bool] = Field(alias="telemetryCapable")
+    trunk_lock_unlock_capable: Optional[bool] = Field(alias="trunkLockUnlockCapable")
+    try_and_play: Optional[bool] = Field(alias="tryAndPlay")
+    vehicle_diagnostic_capable: Optional[bool] = Field(alias="vehicleDiagnosticCapable")
+    vehicle_finder: Optional[bool] = Field(alias="vehicleFinder")
+    vehicle_status: Optional[bool] = Field(alias="vehicleStatus")
+    we_hybrid_capable: Optional[bool] = Field(alias="weHybridCapable")
+    weekly_charge: Optional[bool] = Field(alias="weeklyCharge")
 
 
-class _LinksModel(BaseModel):
+class _LinksModel(CustomBaseModel):
     body: Optional[str]  # TODO unsure what this returns
     button_text: Optional[str] = Field(alias="buttonText")
     image_url: Optional[str] = Field(alias="imageUrl", default=None)
@@ -109,19 +118,19 @@ class _LinksModel(BaseModel):
     name: Optional[str]
 
 
-class _DcmModel(BaseModel):  # Data connection model
+class _DcmModel(CustomBaseModel):  # Data connection model
     country_code: Optional[str] = Field(alias="countryCode", default=None)
-    destination: str = Field(alias="dcmDestination")
-    grade: str = Field(alias="dcmGrade")
-    car_model_year: str = Field(alias="dcmModelYear")
-    supplier: str = Field(alias="dcmSupplier")
+    destination: Optional[str] = Field(alias="dcmDestination")
+    grade: Optional[str] = Field(alias="dcmGrade")
+    car_model_year: Optional[str] = Field(alias="dcmModelYear")
+    supplier: Optional[str] = Field(alias="dcmSupplier")
     supplier_name: Optional[str] = Field(alias="dcmSupplierName", default=None)
-    euicc_id: str = Field(alias="euiccid")
+    euicc_id: Optional[str] = Field(alias="euiccid")
     hardware_type: Optional[str] = Field(alias="hardwareType")
     vehicle_unit_terminal_number: Optional[str] = Field(alias="vehicleUnitTerminalNumber")
 
 
-class _HeadUnitModel(BaseModel):
+class _HeadUnitModel(CustomBaseModel):
     description: Optional[Any] = Field(alias="huDescription")  # TODO unsure what this returns
     generation: Optional[Any] = Field(alias="huGeneration")  # TODO unsure what this returns
     version: Optional[Any] = Field(alias="huVersion")  # TODO unsure what this returns
@@ -131,151 +140,151 @@ class _HeadUnitModel(BaseModel):
     multimedia_type: Optional[Any] = Field(alias="multimediaType")  # TODO unsure what this returns
 
 
-class _SubscriptionsModel(BaseModel):
-    auto_renew: bool = Field(alias="autoRenew")
-    category: str
+class _SubscriptionsModel(CustomBaseModel):
+    auto_renew: Optional[bool] = Field(alias="autoRenew")
+    category: Optional[str]
     components: Optional[Any]  # TODO unsure what this returns
-    consolidated_goodwill_ids: List[Any] = Field(
+    consolidated_goodwill_ids: Optional[List[Any]] = Field(
         alias="consolidatedGoodwillIds"
     )  # TODO unsure what this returns
-    consolidated_product_ids: List[Any] = Field(
+    consolidated_product_ids: Optional[List[Any]] = Field(
         alias="consolidatedProductIds"
     )  # TODO unsure what this returns
-    display_procuct_name: str = Field(alias="displayProductName")
-    display_term: str = Field(alias="displayTerm")
-    future_cancel: bool = Field(alias="futureCancel")
+    display_procuct_name: Optional[str] = Field(alias="displayProductName")
+    display_term: Optional[str] = Field(alias="displayTerm")
+    future_cancel: Optional[bool] = Field(alias="futureCancel")
     good_will_issued_for: Optional[Any] = Field(
         alias="goodwillIssuedFor"
     )  # TODO unsure what this returns
-    product_code: str = Field(alias="productCode")
-    product_description: str = Field(alias="productDescription")
-    product_line: str = Field(alias="productLine")
-    product_name: str = Field(alias="productName")
+    product_code: Optional[str] = Field(alias="productCode")
+    product_description: Optional[str] = Field(alias="productDescription")
+    product_line: Optional[str] = Field(alias="productLine")
+    product_name: Optional[str] = Field(alias="productName")
     procut_type: Optional[Any] = Field(alias="productType")
-    renewable: bool
-    status: str
-    subscription_end_date: date = Field(alias="subscriptionEndDate")
-    subscription_id: str = Field(alias="subscriptionID")
+    renewable: Optional[bool]
+    status: Optional[str]
+    subscription_end_date: Optional[date] = Field(alias="subscriptionEndDate")
+    subscription_id: Optional[str] = Field(alias="subscriptionID")
     subscription_next_billing_date: Optional[Any] = Field(
         alias="subscriptionNextBillingDate",
     )  # TODO unsure what this returns
-    subscription_remaining_days: int = Field(alias="subscriptionRemainingDays")
+    subscription_remaining_days: Optional[int] = Field(alias="subscriptionRemainingDays")
     subscription_remaining_term: Optional[Any] = Field(
         alias="subscriptionRemainingTerm",
     )  # TODO unsure what this returns
-    subscription_start_date: date = Field(alias="subscriptionStartDate")
-    subscription_term: str = Field(alias="subscriptionTerm")
-    term: int
-    term_unit: str = Field(alias="termUnit")
-    type: str
+    subscription_start_date: Optional[date] = Field(alias="subscriptionStartDate")
+    subscription_term: Optional[str] = Field(alias="subscriptionTerm")
+    term: Optional[int]
+    term_unit: Optional[str] = Field(alias="termUnit")
+    type: Optional[str]
 
 
-class _RemoteServiceCapabilitiesModel(BaseModel):
-    acsetting_enabled: bool = Field(alias="acsettingEnabled")
-    allow_hvac_override_capable: bool = Field(alias="allowHvacOverrideCapable")
-    dlock_unlock_capable: bool = Field(alias="dlockUnlockCapable")
-    estart_enabled: bool = Field(alias="estartEnabled")
-    estart_stop_capable: bool = Field(alias="estartStopCapable")
-    estop_enabled: bool = Field(alias="estopEnabled")
-    guest_driver_capable: bool = Field(alias="guestDriverCapable")
-    hazard_capable: bool = Field(alias="hazardCapable")
-    head_light_capable: bool = Field(alias="headLightCapable")
-    moon_roof_capable: bool = Field(alias="moonRoofCapable")
-    power_window_capable: bool = Field(alias="powerWindowCapable")
-    steering_wheel_heater_capable: bool = Field(alias="steeringWheelHeaterCapable")
-    trunk_capable: bool = Field(alias="trunkCapable")
-    vehicle_finder_capable: bool = Field(alias="vehicleFinderCapable")
-    ventilator_capable: bool = Field(alias="ventilatorCapable")
+class _RemoteServiceCapabilitiesModel(CustomBaseModel):
+    acsetting_enabled: Optional[bool] = Field(alias="acsettingEnabled")
+    allow_hvac_override_capable: Optional[bool] = Field(alias="allowHvacOverrideCapable")
+    dlock_unlock_capable: Optional[bool] = Field(alias="dlockUnlockCapable")
+    estart_enabled: Optional[bool] = Field(alias="estartEnabled")
+    estart_stop_capable: Optional[bool] = Field(alias="estartStopCapable")
+    estop_enabled: Optional[bool] = Field(alias="estopEnabled")
+    guest_driver_capable: Optional[bool] = Field(alias="guestDriverCapable")
+    hazard_capable: Optional[bool] = Field(alias="hazardCapable")
+    head_light_capable: Optional[bool] = Field(alias="headLightCapable")
+    moon_roof_capable: Optional[bool] = Field(alias="moonRoofCapable")
+    power_window_capable: Optional[bool] = Field(alias="powerWindowCapable")
+    steering_wheel_heater_capable: Optional[bool] = Field(alias="steeringWheelHeaterCapable")
+    trunk_capable: Optional[bool] = Field(alias="trunkCapable")
+    vehicle_finder_capable: Optional[bool] = Field(alias="vehicleFinderCapable")
+    ventilator_capable: Optional[bool] = Field(alias="ventilatorCapable")
 
 
-class _DataConsentModel(BaseModel):
-    can_300: bool = Field(alias="can300")
-    dealer_contact: bool = Field(alias="dealerContact")
-    service_connect: bool = Field(alias="serviceConnect")
-    ubi: bool = Field(alias="ubi")
+class _DataConsentModel(CustomBaseModel):
+    can_300: Optional[bool] = Field(alias="can300")
+    dealer_contact: Optional[bool] = Field(alias="dealerContact")
+    service_connect: Optional[bool] = Field(alias="serviceConnect")
+    ubi: Optional[bool] = Field(alias="ubi")
 
 
-class _FeaturesModel(BaseModel):
-    ach_payment: bool = Field(alias="achPayment")
-    add_service_record: bool = Field(alias="addServiceRecord")
-    auto_drive: bool = Field(alias="autoDrive")
-    cerence: bool = Field(alias="cerence")
-    charging_station: bool = Field(alias="chargingStation")
-    climate_start_engine: bool = Field(alias="climateStartEngine")
-    collision_assistance: bool = Field(alias="collisionAssistance")
-    connected_card: bool = Field(alias="connectedCard")
-    connected_insurance: bool = Field(alias="connectedInsurance")
-    connected_support: bool = Field(alias="connectedSupport")
-    crash_notification: bool = Field(alias="crashNotification")
-    critical_alert: bool = Field(alias="criticalAlert")
-    dashboard_lights: bool = Field(alias="dashboardLights")
-    dealer_appointment: bool = Field(alias="dealerAppointment")
-    digital_key: bool = Field(alias="digitalKey")
-    door_lock_capable: bool = Field(alias="doorLockCapable")
-    drive_pulse: bool = Field(alias="drivePulse")
-    driver_companion: bool = Field(alias="driverCompanion")
-    driver_score: bool = Field(alias="driverScore")
-    dtc_access: bool = Field(alias="dtcAccess")
-    dynamic_navi: bool = Field(alias="dynamicNavi")
-    eco_history: bool = Field(alias="ecoHistory")
-    eco_ranking: bool = Field(alias="ecoRanking")
-    electric_pulse: bool = Field(alias="electricPulse")
-    emergency_assist: bool = Field(alias="emergencyAssist")
-    enhanced_security_system: bool = Field(alias="enhancedSecuritySystem")
-    ev_charge_station: bool = Field(alias="evChargeStation")
-    ev_remote_services: bool = Field(alias="evRemoteServices")
-    ev_vehicle_status: bool = Field(alias="evVehicleStatus")
-    financial_services: bool = Field(alias="financialServices")
-    flex_rental: bool = Field(alias="flexRental")
-    h2_fuel_station: bool = Field(alias="h2FuelStation")
-    home_charge: bool = Field(alias="homeCharge")
-    how_to_videos: bool = Field(alias="howToVideos")
-    hybrid_pulse: bool = Field(alias="hybridPulse")
-    hydrogen_pulse: bool = Field(alias="hydrogenPulse")
-    important_message: bool = Field(alias="importantMessage")
-    insurance: bool = Field(alias="insurance")
-    last_parked: bool = Field(alias="lastParked")
-    lcfs: bool = Field(alias="lcfs")
-    linked_accounts: bool = Field(alias="linkedAccounts")
-    maintenance_timeline: bool = Field(alias="maintenanceTimeline")
-    marketing_card: bool = Field(alias="marketingCard")
-    marketing_consent: bool = Field(alias="marketingConsent")
-    master_consent_editable: bool = Field(alias="masterConsentEditable")
-    my_destination: bool = Field(alias="myDestination")
-    owners_manual: bool = Field(alias="ownersManual")
-    paid_product: bool = Field(alias="paidProduct")
-    parked_vehicle_locator: bool = Field(alias="parkedVehicleLocator")
-    parking: bool = Field(alias="parking")
-    parking_notes: bool = Field(alias="parkingNotes")
-    personalized_settings: bool = Field(alias="personalizedSettings")
-    privacy: bool = Field(alias="privacy")
-    recent_trip: bool = Field(alias="recentTrip")
-    remote_dtc: bool = Field(alias="remoteDtc")
-    remote_parking: bool = Field(alias="remoteParking")
-    remote_service: bool = Field(alias="remoteService")
-    roadside_assistance: bool = Field(alias="roadsideAssistance")
-    safety_recall: bool = Field(alias="safetyRecall")
-    schedule_maintenance: bool = Field(alias="scheduleMaintenance")
-    service_history: bool = Field(alias="serviceHistory")
-    shop_genuine_parts: bool = Field(alias="shopGenuineParts")
-    smart_charging: bool = Field(alias="smartCharging")
-    ssa_download: bool = Field(alias="ssaDownload")
-    sxm_radio: bool = Field(alias="sxmRadio")
-    telemetry: bool = Field(alias="telemetry")
-    tff: bool = Field(alias="tff")
-    tire_pressure: bool = Field(alias="tirePressure")
-    v1g: bool = Field(alias="v1g")
-    va_setting: bool = Field(alias="vaSetting")
-    vehicle_diagnostic: bool = Field(alias="vehicleDiagnostic")
-    vehicle_health_report: bool = Field(alias="vehicleHealthReport")
-    vehicle_specifications: bool = Field(alias="vehicleSpecifications")
-    vehicle_status: bool = Field(alias="vehicleStatus")
-    we_hybrid: bool = Field(alias="weHybrid")
-    wifi: bool = Field(alias="wifi")
-    xcapp: bool = Field(alias="xcapp")
+class _FeaturesModel(CustomBaseModel):
+    ach_payment: Optional[bool] = Field(alias="achPayment")
+    add_service_record: Optional[bool] = Field(alias="addServiceRecord")
+    auto_drive: Optional[bool] = Field(alias="autoDrive")
+    cerence: Optional[bool] = Field(alias="cerence")
+    charging_station: Optional[bool] = Field(alias="chargingStation")
+    climate_start_engine: Optional[bool] = Field(alias="climateStartEngine")
+    collision_assistance: Optional[bool] = Field(alias="collisionAssistance")
+    connected_card: Optional[bool] = Field(alias="connectedCard")
+    connected_insurance: Optional[bool] = Field(alias="connectedInsurance")
+    connected_support: Optional[bool] = Field(alias="connectedSupport")
+    crash_notification: Optional[bool] = Field(alias="crashNotification")
+    critical_alert: Optional[bool] = Field(alias="criticalAlert")
+    dashboard_lights: Optional[bool] = Field(alias="dashboardLights")
+    dealer_appointment: Optional[bool] = Field(alias="dealerAppointment")
+    digital_key: Optional[bool] = Field(alias="digitalKey")
+    door_lock_capable: Optional[bool] = Field(alias="doorLockCapable")
+    drive_pulse: Optional[bool] = Field(alias="drivePulse")
+    driver_companion: Optional[bool] = Field(alias="driverCompanion")
+    driver_score: Optional[bool] = Field(alias="driverScore")
+    dtc_access: Optional[bool] = Field(alias="dtcAccess")
+    dynamic_navi: Optional[bool] = Field(alias="dynamicNavi")
+    eco_history: Optional[bool] = Field(alias="ecoHistory")
+    eco_ranking: Optional[bool] = Field(alias="ecoRanking")
+    electric_pulse: Optional[bool] = Field(alias="electricPulse")
+    emergency_assist: Optional[bool] = Field(alias="emergencyAssist")
+    enhanced_security_system: Optional[bool] = Field(alias="enhancedSecuritySystem")
+    ev_charge_station: Optional[bool] = Field(alias="evChargeStation")
+    ev_remote_services: Optional[bool] = Field(alias="evRemoteServices")
+    ev_vehicle_status: Optional[bool] = Field(alias="evVehicleStatus")
+    financial_services: Optional[bool] = Field(alias="financialServices")
+    flex_rental: Optional[bool] = Field(alias="flexRental")
+    h2_fuel_station: Optional[bool] = Field(alias="h2FuelStation")
+    home_charge: Optional[bool] = Field(alias="homeCharge")
+    how_to_videos: Optional[bool] = Field(alias="howToVideos")
+    hybrid_pulse: Optional[bool] = Field(alias="hybridPulse")
+    hydrogen_pulse: Optional[bool] = Field(alias="hydrogenPulse")
+    important_message: Optional[bool] = Field(alias="importantMessage")
+    insurance: Optional[bool] = Field(alias="insurance")
+    last_parked: Optional[bool] = Field(alias="lastParked")
+    lcfs: Optional[bool] = Field(alias="lcfs")
+    linked_accounts: Optional[bool] = Field(alias="linkedAccounts")
+    maintenance_timeline: Optional[bool] = Field(alias="maintenanceTimeline")
+    marketing_card: Optional[bool] = Field(alias="marketingCard")
+    marketing_consent: Optional[bool] = Field(alias="marketingConsent")
+    master_consent_editable: Optional[bool] = Field(alias="masterConsentEditable")
+    my_destination: Optional[bool] = Field(alias="myDestination")
+    owners_manual: Optional[bool] = Field(alias="ownersManual")
+    paid_product: Optional[bool] = Field(alias="paidProduct")
+    parked_vehicle_locator: Optional[bool] = Field(alias="parkedVehicleLocator")
+    parking: Optional[bool] = Field(alias="parking")
+    parking_notes: Optional[bool] = Field(alias="parkingNotes")
+    personalized_settings: Optional[bool] = Field(alias="personalizedSettings")
+    privacy: Optional[bool] = Field(alias="privacy")
+    recent_trip: Optional[bool] = Field(alias="recentTrip")
+    remote_dtc: Optional[bool] = Field(alias="remoteDtc")
+    remote_parking: Optional[bool] = Field(alias="remoteParking")
+    remote_service: Optional[bool] = Field(alias="remoteService")
+    roadside_assistance: Optional[bool] = Field(alias="roadsideAssistance")
+    safety_recall: Optional[bool] = Field(alias="safetyRecall")
+    schedule_maintenance: Optional[bool] = Field(alias="scheduleMaintenance")
+    service_history: Optional[bool] = Field(alias="serviceHistory")
+    shop_genuine_parts: Optional[bool] = Field(alias="shopGenuineParts")
+    smart_charging: Optional[bool] = Field(alias="smartCharging")
+    ssa_download: Optional[bool] = Field(alias="ssaDownload")
+    sxm_radio: Optional[bool] = Field(alias="sxmRadio")
+    telemetry: Optional[bool] = Field(alias="telemetry")
+    tff: Optional[bool] = Field(alias="tff")
+    tire_pressure: Optional[bool] = Field(alias="tirePressure")
+    v1g: Optional[bool] = Field(alias="v1g")
+    va_setting: Optional[bool] = Field(alias="vaSetting")
+    vehicle_diagnostic: Optional[bool] = Field(alias="vehicleDiagnostic")
+    vehicle_health_report: Optional[bool] = Field(alias="vehicleHealthReport")
+    vehicle_specifications: Optional[bool] = Field(alias="vehicleSpecifications")
+    vehicle_status: Optional[bool] = Field(alias="vehicleStatus")
+    we_hybrid: Optional[bool] = Field(alias="weHybrid")
+    wifi: Optional[bool] = Field(alias="wifi")
+    xcapp: Optional[bool] = Field(alias="xcapp")
 
 
-class VehicleGuidModel(BaseModel):
+class VehicleGuidModel(CustomBaseModel):
     """Model representing a vehicle with its associated information.
 
     Attributes
@@ -359,86 +368,88 @@ class VehicleGuidModel(BaseModel):
 
     """
 
-    alerts: List[Any]  # TODO unsure what this returns
-    asi_code: str = Field(alias="asiCode")
-    brand: str
-    capabilities: List[_CapabilitiesModel]
-    car_line_name: str = Field(alias="carlineName")
-    color: str
-    commercial_rental: bool = Field(alias="commercialRental")
-    contract_id: str = Field(alias="contractId")
-    cts_links: _LinksModel = Field(alias="ctsLinks")
-    data_consent: _DataConsentModel = Field(alias="dataConsent")
+    alerts: Optional[List[Any]]  # TODO unsure what this returns
+    asi_code: Optional[str] = Field(alias="asiCode")
+    brand: Optional[str]
+    capabilities: Optional[List[_CapabilitiesModel]]
+    car_line_name: Optional[str] = Field(alias="carlineName")
+    color: Optional[str]
+    commercial_rental: Optional[bool] = Field(alias="commercialRental")
+    contract_id: Optional[str] = Field(alias="contractId")
+    cts_links: Optional[_LinksModel] = Field(alias="ctsLinks")
+    data_consent: Optional[_DataConsentModel] = Field(alias="dataConsent")
     date_of_first_use: Optional[date] = Field(alias="dateOfFirstUse")
     dcm: Optional[_DcmModel] = None
-    dcm_active: bool = Field(alias="dcmActive")
+    dcm_active: Optional[bool] = Field(alias="dcmActive")
     dcms: Optional[Any]  # TODO unsure what this returns
-    display_model_description: str = Field(alias="displayModelDescription")
-    display_subscriptions: List[Dict[str, str]] = Field(alias="displaySubscriptions")
+    display_model_description: Optional[str] = Field(alias="displayModelDescription")
+    display_subscriptions: Optional[List[Dict[str, str]]] = Field(alias="displaySubscriptions")
     electrical_platform_code: Optional[str] = Field(alias="electricalPlatformCode", default=None)
     emergency_contact: Optional[Any] = Field(
         alias="emergencyContact"
     )  # TODO unsure what this returns
-    ev_vehicle: bool = Field(alias="evVehicle")
-    extended_capabilities: _ExtendedCapabilitiesModel = Field(alias="extendedCapabilities")
+    ev_vehicle: Optional[bool] = Field(alias="evVehicle")
+    extended_capabilities: Optional[_ExtendedCapabilitiesModel] = Field(
+        alias="extendedCapabilities"
+    )
     external_subscriptions: Optional[Any] = Field(alias="externalSubscriptions")
-    family_sharing: bool = Field(alias="familySharing")
-    faq_url: str = Field(alias="faqUrl")
-    features: _FeaturesModel
+    family_sharing: Optional[bool] = Field(alias="familySharing")
+    faq_url: Optional[str] = Field(alias="faqUrl")
+    features: Optional[_FeaturesModel]
     fleet_ind: Optional[Any] = Field(alias="fleetInd")  # TODO unsure what this returns
     fuel_type: Optional[str] = Field(alias="fuelType", default=None)
-    generation: str
-    head_unit: _HeadUnitModel = Field(alias="headUnit")
+    generation: Optional[str]
+    head_unit: Optional[_HeadUnitModel] = Field(alias="headUnit")
     hw_type: Optional[Any] = Field(alias="hwType")  # TODO unsure what this returns
-    image: str
-    imei: str
-    katashiki_code: str = Field(alias="katashikiCode")
-    manufactured_date: date = Field(alias="manufacturedDate")
-    manufactured_code: str = Field(alias="manufacturerCode")
-    car_model_code: str = Field(alias="modelCode")
-    car_model_description: str = Field(alias="modelDescription")
-    car_model_name: str = Field(alias="modelName")
-    car_model_year: str = Field(alias="modelYear")
+    image: Optional[str]
+    imei: Optional[str]
+    katashiki_code: Optional[str] = Field(alias="katashikiCode")
+    manufactured_date: Optional[date] = Field(alias="manufacturedDate")
+    manufactured_code: Optional[str] = Field(alias="manufacturerCode")
+    car_model_code: Optional[str] = Field(alias="modelCode")
+    car_model_description: Optional[str] = Field(alias="modelDescription")
+    car_model_name: Optional[str] = Field(alias="modelName")
+    car_model_year: Optional[str] = Field(alias="modelYear")
     nickname: Optional[str] = Field(alias="nickName", default=None)
-    non_cvt_vehicle: bool = Field(alias="nonCvtVehicle")
+    non_cvt_vehicle: Optional[bool] = Field(alias="nonCvtVehicle")
     old_imei: Optional[Any] = Field(alias="oldImei")  # TODO unsure what this returns
-    owner: bool
-    personalized_settings: _LinksModel = Field(
+    owner: Optional[bool]
+    personalized_settings: Optional[_LinksModel] = Field(
         alias="personalizedSettings"
     )  # TODO unsure what this returns
     preferred: Optional[bool] = None
-    primary_subscriber: bool = Field(alias="primarySubscriber")
-    region: str
+    primary_subscriber: Optional[bool] = Field(alias="primarySubscriber")
+    region: Optional[str]
     registration_number: Optional[str] = Field(alias="registrationNumber")
     remote_display: Optional[Any] = Field(alias="remoteDisplay")  # TODO unsure what this returns
-    remote_service_capabilities: _RemoteServiceCapabilitiesModel = Field(
+    remote_service_capabilities: Optional[_RemoteServiceCapabilitiesModel] = Field(
         alias="remoteServiceCapabilities"
     )
-    remote_service_exceptions: List[Any] = Field(
+    remote_service_exceptions: Optional[List[Any]] = Field(
         alias="remoteServicesExceptions"
     )  # TODO unsure what this returns
-    remote_subscription_exists: bool = Field(alias="remoteSubscriptionExists")
-    remote_subscription_status: str = Field(alias="remoteSubscriptionStatus")
-    remote_user: bool = Field(alias="remoteUser")
+    remote_subscription_exists: Optional[bool] = Field(alias="remoteSubscriptionExists")
+    remote_subscription_status: Optional[str] = Field(alias="remoteSubscriptionStatus")
+    remote_user: Optional[bool] = Field(alias="remoteUser")
     remote_user_guid: Optional[Union[UUID, str]] = Field(alias="remoteUserGuid", default=None)
     service_connect_status: Optional[Any] = Field(
         alias="serviceConnectStatus"
     )  # TODO unsure what this returns
-    services: List[Any]  # TODO unsure what this returns
+    services: Optional[List[Any]]  # TODO unsure what this returns
     shop_genuine_parts_url: Optional[str] = Field(alias="shopGenuinePartsUrl")
-    status: str
-    stock_pic_reference: str = Field(alias="stockPicReference")
-    subscriber_guid: UUID = Field(alias="subscriberGuid")
-    subscription_expiration_status: bool = Field(alias="subscriptionExpirationStatus")
-    subscription_status: str = Field(alias="subscriptionStatus")
-    subscriptions: List[_SubscriptionsModel]
+    status: Optional[str]
+    stock_pic_reference: Optional[str] = Field(alias="stockPicReference")
+    subscriber_guid: Optional[UUID] = Field(alias="subscriberGuid")
+    subscription_expiration_status: Optional[bool] = Field(alias="subscriptionExpirationStatus")
+    subscription_status: Optional[str] = Field(alias="subscriptionStatus")
+    subscriptions: Optional[List[_SubscriptionsModel]]
     suffix_code: Optional[Any] = Field(alias="suffixCode")
-    svl_satus: bool = Field(alias="svlStatus")
-    tff_links: _LinksModel = Field(alias="tffLinks")
-    transmission_type: str = Field(alias="transmissionType")
-    vehicle_capabilities: List[Any] = Field(alias="vehicleCapabilities")
+    svl_satus: Optional[bool] = Field(alias="svlStatus")
+    tff_links: Optional[_LinksModel] = Field(alias="tffLinks")
+    transmission_type: Optional[str] = Field(alias="transmissionType")
+    vehicle_capabilities: Optional[List[Any]] = Field(alias="vehicleCapabilities")
     vehicle_data_consents: Optional[Any] = Field(alias="vehicleDataConsents")
-    vin: str
+    vin: Optional[str]
 
 
 class VehiclesResponseModel(StatusModel):

--- a/mytoyota/models/endpoints/vehicle_health.py
+++ b/mytoyota/models/endpoints/vehicle_health.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from mytoyota.models.endpoints.common import StatusModel
+from mytoyota.utils.models import CustomBaseModel
 
 
-class VehicleHealthModel(BaseModel):
+class VehicleHealthModel(CustomBaseModel):
     r"""Model representing the health status of a vehicle.
 
     Attributes
@@ -23,9 +24,9 @@ class VehicleHealthModel(BaseModel):
     quantity_of_eng_oil_icon: Optional[List[Any]] = Field(
         alias="quantityOfEngOilIcon"
     )  # TODO unsure what this returns
-    vin: str
+    vin: Optional[str]
     warning: Optional[List[Any]]  # TODO unsure what this returns
-    wng_last_upd_time: datetime = Field(alias="wnglastUpdTime")
+    wng_last_upd_time: Optional[datetime] = Field(alias="wnglastUpdTime")
 
 
 class VehicleHealthResponseModel(StatusModel):

--- a/mytoyota/utils/models.py
+++ b/mytoyota/utils/models.py
@@ -1,0 +1,25 @@
+"""Utilities for manipulating or extend pydantic models."""
+from pydantic import BaseModel, root_validator
+
+
+class CustomBaseModel(BaseModel):
+    """Model that automatically returns values that cannot be parsed correctly as 'None' value."""
+
+    @root_validator(pre=True)
+    def invalid_to_none(cls, values: dict[str, object]) -> dict[str, object]:  # noqa: N805
+        """Pydantic Root validator parsing config."""
+        validated_values: dict[str, object] = {}
+        for name, value in values.items():
+            field = cls.__fields__.get(name)
+            if field is None:  # must be extra data
+                continue
+            validated_value, errors = field.validate(
+                value,
+                validated_values,
+                loc="__root__",
+                cls=cls,  # type: ignore[arg-type]
+            )
+            validated_values[name] = validated_value
+            if errors:
+                values[name] = None
+        return values

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "anyio"
-version = "4.2.0"
+version = "4.4.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anyio-4.2.0-py3-none-any.whl", hash = "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee"},
-    {file = "anyio-4.2.0.tar.gz", hash = "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f"},
+    {file = "anyio-4.4.0-py3-none-any.whl", hash = "sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7"},
+    {file = "anyio-4.4.0.tar.gz", hash = "sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94"},
 ]
 
 [package.dependencies]
@@ -104,13 +104,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.0"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
-    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -118,18 +118,18 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.13.1"
+version = "3.15.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.1-py3-none-any.whl", hash = "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"},
-    {file = "filelock-3.13.1.tar.gz", hash = "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e"},
+    {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
+    {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.24)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -164,13 +164,13 @@ yaml = ["pyyaml (==6.0.1)"]
 
 [[package]]
 name = "httpcore"
-version = "1.0.2"
+version = "1.0.5"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.2-py3-none-any.whl", hash = "sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7"},
-    {file = "httpcore-1.0.2.tar.gz", hash = "sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535"},
+    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
+    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
 ]
 
 [package.dependencies]
@@ -181,7 +181,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.23.0)"]
+trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
@@ -209,13 +209,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "identify"
-version = "2.5.33"
+version = "2.6.0"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.33-py2.py3-none-any.whl", hash = "sha256:d40ce5fcd762817627670da8a7d8d8e65f24342d14539c59488dc603bf662e34"},
-    {file = "identify-2.5.33.tar.gz", hash = "sha256:161558f9fe4559e1557e1bff323e8631f6a0e4837f7497767c1782832f16b62d"},
+    {file = "identify-2.6.0-py2.py3-none-any.whl", hash = "sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0"},
+    {file = "identify-2.6.0.tar.gz", hash = "sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf"},
 ]
 
 [package.extras]
@@ -300,80 +300,99 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "marisa-trie"
-version = "1.1.0"
+version = "1.2.0"
 description = "Static memory-efficient and fast Trie-like structures for Python."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "marisa-trie-1.1.0.tar.gz", hash = "sha256:5bf43ed0cf36af4578fe7b034cf95f532439766516680e4bd603723611ebd56b"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ed1b37ef1444083ab11e15d9150861874d8dd7be70c8899eccf1b986d37823a5"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:119366f9db9f53242439f69c3d49a3f1a3912970bc29b9af6ed9b6d0b7ef8c9e"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6964bfa23af502591094712e79886974a631d8047eb72cdf646babc62b03ae5e"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab8ec133daabb288e832d448fdff2e71756e7ba5ea7ff1b7b7645b010b2c23ac"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:61a52a0e5ef404bfdcc2117cd39cb572595ff01f73f27feb5fc9e92889adbae0"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9ce60c2ed4f4138ef78e346d43b105185977c6be7bce0609b48bb14092110612"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:3b90a422eb660bd111ffe54290bfbabf98a30fccfe8a594a512b3ba81fda8aa5"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-win32.whl", hash = "sha256:6b92cd77787aeb92fd815a5ad00d4828f528d30032c1314d5f17571afe125cbe"},
-    {file = "marisa_trie-1.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:d415c11aada47f7f4afb818ce92e46c8f1b55611d325c09df7070088cfaa24bb"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:68a71ebb12498ad82e1579f41efe52c91839d92c0823a79389924057094c0a68"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1de6df9686175feb48f1e271a9252f6bf7ce1a4669a5bab3a97dffb8b11b13e6"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:789374ab88afe9e8ecfbd03a213f7b11fbefb3a8286c8fad88a2da0d7e5e0ef9"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0f1b05f7dcde6ca2b460126519a37707fde53808b9e29e6d5b44de737262104"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:312e414001e5777506f459fa3032c3a5827e80a32babfd44ab528dd0fb824e61"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:571f68432d3dbf06b715cbb6aed1eed9898c149619045d65e6d82407d4eb4c9e"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c1d98fe7da386c7f789526d8cf0b824b87fa1019e52619f8ad5e877912cc0f71"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-win32.whl", hash = "sha256:953400c8d7639349df9ef3f899f67c158852416a0470e7221fb06f19e3b1d0f6"},
-    {file = "marisa_trie-1.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:c423e651daec5931371fa3d480fb5ac59164ed7dea968d8f51b1ba369bac4975"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:9f4a37a17b9a551d1678b909c44841109b9979d12e72a9ed6e922a51f41889f1"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:bbc118727474d710851db69d2762b4a3936ad1d2ffebb519c3f8f42a925fa118"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c74557386eb62ce6526a9d0ad44410530e973feee5e0cabebf57b4d72696b2a"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4af7893ffc7099b68fd9d667fecc50d38e3e49405fcd6be97bc5ec72816ffa2"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:690eb9af9c0f4c677b74077843d0afafd08e543cdb3905b8a354aa0b0a2c06c3"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7e1771bedce1d9c37931c5efffac23aaed32f1364b99420673fa9417a0b5a6f1"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:38a64b1b4cbab19c23cfabed654c99e072af1c574f54b57ededd81357382d679"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-win32.whl", hash = "sha256:92cfb535174d711c3dbb3a9f3bbbd5abd180e778cd8ba2839a34565294c33190"},
-    {file = "marisa_trie-1.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:9f0cd1d11f7f7022a044a32a59632f18af91ee31fa84ff98c914cb5b9fae449d"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:1d95308e0453302706d5246935beb9e3255c20238a633d0637b3d345de428aa3"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dbff54cf950dccc8bded31ad130571330efd1d6849fbcc7825e62ac5063bd0a"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c14e494b28f78f806f5320f02b8625770d598bff0a4ea45f825f55257efcaf52"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:2484e83b9c233b337f45bb09740a74aeb510081856cdd4b293b48b970c710c1d"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f661d79e5fef5c38ab41fd5a16c29f8bd9d46a0de6c407b88ebbf24c7637ac84"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-win32.whl", hash = "sha256:5998b16395cefd76c52ce8cae35b837254ff097d3a357023f592218ff9d2112b"},
-    {file = "marisa_trie-1.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0b5d97515d9d65f237049ba01d385455fe5cc8dfb9c97b4a5b976382b9aff6c1"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4407e7ec82cdb501015188f1895bbdcac1a5ecb0e5ecc5cbbba028d5940499f2"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:de62a115afd157fe6cfc8e4194905605c4603c6664eac30788f3f6866b67345f"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d7e17abb08ada031c86835e358242b6a2dc6645e1a872e30e1ce1c1b1cd6317d"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac288cb48e09927d96d00f4b2ad7bbfad91ce2e20fc6e6bb8b61dda05dbc28d2"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:da0d59b93a327d772b49d9a79ef11f2e1c23aaafcefeab95376447794318d189"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:d810f95a548751484bd57cfe5940ea5423d4e39678a10c9582b3f102fac27bbe"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:521a954dd469a336e3c8a307f7fe7ba272032d77cc8f801edebf2d11549ac1c2"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-win32.whl", hash = "sha256:1b25422875673ca5a15e236f2158f6a277f7252057272bb0b51272f4a9d3c401"},
-    {file = "marisa_trie-1.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:c80b85559e09ec7f69b9f623ea06fd5cfe25ead20bb4a09c20e879cd1851db35"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:844a56eebe32b098b6d97af28bfa9ca576400b5560be8a09c021a521faadee4a"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:917ef793e0e90bd01fc436cebf93707de1ac31f2feadc4d4b0ddbdb9522617d5"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e09cb17288a5a43431e23737d2d91bd54e6d694380740267960dbc7ab96ad69d"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5353d3c8c48524aac40c325794d6227c59e517a68746d3a0524608a20438a1e9"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d4dd18d1c67a949eeaba16385ab2c1a3e1eb7a2acb982c3744193a59df30cfd"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4a9a17507211700c77849d1caf4e6a64756536e491327cda3ea12259ce70eae5"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6699b0d3ca090172713bfbb9ef8063bfe27cae8d05121d5f71d1c4048b57936d"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-win32.whl", hash = "sha256:b4450a4917af45614edc3da1ab1b927b96de01e5742719c330e6d4a0e36fee7d"},
-    {file = "marisa_trie-1.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:89ba0ba6a05683d1ea966afe7aeae114d13fd8f354c6692a90bc2b181657ccbf"},
-    {file = "marisa_trie-1.1.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:10665a17a7965c2a49b2dda6beb14cf206f6932f013ca0337105a8744d67395d"},
-    {file = "marisa_trie-1.1.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86365aac6dde7228b0090d0e993f3ed557a43111cbe3b397f1bad77febbab342"},
-    {file = "marisa_trie-1.1.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:086d7c2b45b03185c70431450e7b92e76d3f3333074bf9b3aabb2eb6e1b85f89"},
-    {file = "marisa_trie-1.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:9e5450eb023bf7a232cdaaf18fbe67fe45ed724d5cb30dd35f48c3a723ad3a4f"},
-    {file = "marisa_trie-1.1.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:206db942691d82310cdb6c59e34acbe648766ddb569c13de8b534e17892c608c"},
-    {file = "marisa_trie-1.1.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff2e12de8aea7fde90b4128bb8340a99cfb4a55e4c41b6336d187660e899385"},
-    {file = "marisa_trie-1.1.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b8652141e4623b36017275a6ae6efe7a2ece3b304b984d4f66acb620a78eed9"},
-    {file = "marisa_trie-1.1.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:7916ddd3cf621a20285256e4e5e5e7e6c86aa29356faa31cc8de535b8b71afe3"},
-    {file = "marisa_trie-1.1.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2c57f2d6caa71829973a18b80c70b422337328686d3c7ea4519082f0b291fa01"},
-    {file = "marisa_trie-1.1.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd45429b25098034a9ca2fc78877e3edc9d59f88ca8b3c69cff5f299c728d771"},
-    {file = "marisa_trie-1.1.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:71ee2edb2574b87a2173d64dd3f79c8e1af2e8d7bd1469bdcfe5fd895ada913a"},
-    {file = "marisa_trie-1.1.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:427ce824566382309a300a8d080a84ccf6795325204c834839bdcb41203591f4"},
-    {file = "marisa_trie-1.1.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:37fcb2265d73a5c04829b25af7cdf819a27d71a898a6e1b54822e006f1843c94"},
-    {file = "marisa_trie-1.1.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b34ea73a92c35577171bf9d8216e6c57acdf08b77b5d84f1efad8cf721159da"},
-    {file = "marisa_trie-1.1.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fdd7445f2f2785c02c18d46acf0c14baffafa6e7e73b3e9052b512e1f7dadbb3"},
-    {file = "marisa_trie-1.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e0f4c47fca455bd75cab9e2181138d3978721ed546e2ed18e83b0852c49eca4f"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:61fab91fef677f0af0e818e61595f2334f7e0b3e122b24ec65889aae69ba468d"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5f5b3080316de735bd2b07265de5eea3ae176fa2fc60f9871aeaa9cdcddfc8f7"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:77bfde3287314e91e28d3a882c7b87519ef0ee104c921df72c7819987d5e4863"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4fbb1ec1d9e891060a0aee9f9c243acec63de1e197097a14850ba38ec8a4013"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e04e9c86fe8908b61c2aebb8444217cacaed15b93d2dccaac3849e36a6dc660"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a7c75a508f44e40f7af8448d466045a97534adcbb026e63989407cefb9ebfa6"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5321211647609869907e81b0230ad2dfdfa7e19fe1ee469b46304a622391e6a1"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:88660e6ee0f821872aaf63ba4b9a7513428b9cab20c69cc013c368bd72c3a4fe"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e4535fc5458de2b59789e574cdd55923d63de5612dc159d33941af79cd62786"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-win32.whl", hash = "sha256:bdd1d4d430e33abbe558971d1bd57da2d44ca129fa8a86924c51437dba5cb345"},
+    {file = "marisa_trie-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:c729e2b8f9699874b1372b5a01515b340eda1292f5e08a3fe4633b745f80ad7a"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d62985a0e6f2cfeb36cd6afa0460063bbe83ef4bfd9afe189a99103487547210"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1890cc993149db4aa8242973526589e8133c3f92949b0ac74c2c9a6596707ae3"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26177cd0dadb7b44f47c17c40e16ac157c4d22ac7ed83b5a47f44713239e10d1"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3425dc81d49a374be49e3a063cb6ccdf57973201b0a30127082acea50562a85e"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:525b8df41a1a7337ed7f982eb63b704d7d75f047e30970fcfbe9cf6fc22c5991"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c643c66bbde6a115e4ec8713c087a9fe9cb7b7c684e6af4cf448c120fa427ea4"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5a83fe83e0eab9154a2dc7c556898c86584b7779ddf4214c606fce4ceff07c13"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:49701db6bb8f1ec0133abd95f0a4891cfd6f84f3bd019e343037e31a5a5b0210"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a3f0562863deaad58c5dc3a51f706da92582bc9084189148a45f7a12fe261a51"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-win32.whl", hash = "sha256:b08968ccad00f54f31e38516e4452fae59dd15a3fcee56aea3101ba2304680b3"},
+    {file = "marisa_trie-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3ef375491e7dd71a0a7e7bf288c88750942bd1ee0c379dcd6ad43e31af67d00"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:39b88f126988ea83e8458259297d2b2f9391bfba8f4dc5d7a246813aae1c1def"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ec167b006884a90d130ee30518a9aa44cb40211f702bf07031b2d7d4d1db569b"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b855e6286faef5411386bf9d676dfb545c09f7d109f197f347c9366aeb12f07"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cd287ff323224d87c2b739cba39614aac3737c95a254e0ff70e77d9b8df226d"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d8a1c0361165231f4fb915237470afc8cc4803c535f535f4fc42ca72855b124"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3267f438d258d7d85ee3dde363c4f96c3196ca9cd9e63fe429a59543cc544b15"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c87a0c2cccce12b07bfcb70708637c0816970282d966a1531ecda1a24bd1cc8"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d3c0e38f0501951e2322f7274a39b8e2344bbd91ceaa9da439f46022570ddc9d"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cd88a338c87e6dc130b6cea7b697580c21f0c83a8a8b46671cfecbb713d3fe24"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-win32.whl", hash = "sha256:5cea60975184f03fbcff51339df0eb44d2abe106a1693983cc64415eb87b897b"},
+    {file = "marisa_trie-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b04a07b99b62b9bdf3eaf1d44571a3293ce249ce8971944e780c9c709593462f"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c11af35d9304de420b359741e12b885d04f11403697efcbbe8cb50f834261ebc"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2db8e74493c3bffb480c54afaa88890a39bf90063ff5b322acf64bf076e4b36e"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9bcc6613bc873136dc62609b66aaa27363e2bd46c03fdab62d638f7cf69d5f82"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f5cb731581effb3e05258f3ddc2a155475de74bb00f61eb280f991e13b48f783"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:eba1061bbeaeec4149282beab2ae163631606f119f549a10246b014e13f9047b"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:015594427360c6ad0fa94d51ee3d50fb83b0f7278996497fd2d69f877c3de9bd"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:36d65bcbf22a70cdd0202bd8608c2feecc58bdb9e5dd9a2f5a723b651fcab287"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:bc138625b383998f5cd0cbf6cd38d66d414f3786ae6d7b4e4a6fc970140ef4e9"},
+    {file = "marisa_trie-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:27d270a64eb655754dfb4e352c60a084b16ab999b3a97a0cdc7dbecbca3c0e35"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fa1fa7f67d317a921315a65e266b9e156ce5a956076ec2b6dbf72d67c7df8216"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9dccef41d4af11a03558c1d101de58bd723b3039a5bc4e064250008c118037ec"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:873efd212dfef2b736ff2ff43e10b348c428d5dbac7b8cb8aa777004bc8c7b0e"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8af7a21ac2ba6dc23e4257fc3a40b3070e776275d3d0b5b2ef44473ad92caf3a"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7202ba0ca1db5245feaebbeb3d0c776b2da1fffb0abc3500dd505f679686aa1"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83d90be28c083323909d23ff8e9b4a2764b9e75520d1bae1a277e9fa7ca20d15"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:40e2a374026492ac84232897f1f1d8f92a4a1f8bcf3f0ded1f2b8b708d1acfff"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:7c6e6506bd24a5799b9b4b9cf1e8d6fa281f136396ba018a95d95d4d74715227"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:437bf6c0d7ba4cf17656a0e3bdd0b3c2c92c01fedfa670904177eef3116a4f45"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-win32.whl", hash = "sha256:6aeef7b364fb3b34dbba1cc57b79f1668fad0c3f039738d65a5b0d5ddce15f47"},
+    {file = "marisa_trie-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:02f773e85cc566a24c0e0e28c744052db7691c4f13d02e4257bc657a49b9ab14"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6ff705cb3b907bdeacb8c4b3bf0541691f52b101014d189a707ca41ebfacad59"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:006419c59866979188906babc42ae0918081c18cabc2bdabca027f68c081c127"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7196691681ecb8a12629fb6277c33bafdb27cf2b6c18c28bc48fa42a15eab8f"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaf052c0a1f4531ee12fd4c637212e77ad2af8c3b38a0d3096622abd01a22212"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fb95f3ab95ba933f6a2fa2629185e9deb9da45ff2aa4ba8cc8f722528c038ef"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7459b1e1937e33daed65a6d55f8b95f9a8601f4f8749d01641cf548ecac03840"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:902ea948677421093651ca98df62d255383f865f7c353f956ef666e92500e79f"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:fdf7a2d066907816726f3bf241b8cb05b698d6ffaa3c5ea2658d4ba69e87ec57"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3540bb85b38dfc17060263e061c95a0a435681b04543d1ae7e8d7441a9790593"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-win32.whl", hash = "sha256:fe1394e1f262e5b45d22d30bd1ef75174d1f2772e86716b5f93f9c29dfc1a779"},
+    {file = "marisa_trie-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:84c44cb13803723f0f76aa2ba1a657f762a0bb9d8a9b80dfff249bb1c3218dd6"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:035c4c8f3b313b4d7b7451ddd539da811a11077a9e359c6a0345f816b1bdccb3"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d4f05c2ee218a5ab09d269b640d06f9708b0cf37c842344cbdffb0661c74c472"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92ac63e1519598de946c7d9346df3bb52ed96968eb3021b4e89b51d79bc72a86"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:045f32eaeb5dcdb5beadb571ba616d7a34141764b616eebb4decce71b366f5fa"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb60c2f9897ce2bfc31a69ac25a040de4f8643ab2a339bb0ff1185e1a9dedaf8"},
+    {file = "marisa_trie-1.2.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f19c5fcf23c02f1303deb69c67603ee37ed8f01de2d8b19f1716a6cf5afd5455"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a06a77075240eb83a47b780902322e66c968a06a2b6318cab06757c65ea64190"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:125016400449e46ec0e5fabd14c8314959c4dfa02ffc2861195c99efa2b5b011"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c57647dd9f9ba16fc5bb4679c915d7d48d5c0b25134fb10f095ccd839686a027"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6601e74338fb31e1b20674257706150113463182a01d3a1310df6b8840720b17"},
+    {file = "marisa_trie-1.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ce2f68e1000c4c72820c5b2c9d037f326fcf75f036453a5e629f225f99b92cfc"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:069ac10a133d96b3f3ed1cc071b973a3f28490345e7941c778a1d81cf176f04a"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:de9911480ce2a0513582cb84ee4484e5ee8791e692276c7f5cd7378e114d1988"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cfec001cf233e8853a29e1c2bb74031c217aa61e7bd19389007e04861855731"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd1f3ef8de89684fbdd6aaead09d53b82e718bad4375d2beb938cbd24b48c51a"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:65f5d8c1ecc85283b5b03a1475a5da723b94b3beda752c895b2f748477d8f1b1"},
+    {file = "marisa_trie-1.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:2e7540f844c1de493a90ad7d0f5bffc6a2cba19fe312d6db7b97aceff11d97f8"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:2fb9243f66563285677079c9dccc697d35985287bacb36c8e685305687b0e025"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:58e2b84cbb6394f9c567f1f4351fc2995a094e1b684da9b577d4139b145401d6"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b4a8d3ed1f1b8f551b52e11a1265eaf0718f06bb206654b2c529cecda0913dd"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97652c5fbc92f52100afe1c4583625015611000fa81606ad17f1b3bbb9f3bfa"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7183d84da20c89b2a366bf581f0d79d1e248909678f164e8536f291120432e8"},
+    {file = "marisa_trie-1.2.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c7f4df4163202b0aa5dad3eeddf088ecb61e9101986c8b31f1e052ebd6df9292"},
+    {file = "marisa_trie-1.2.0.tar.gz", hash = "sha256:fedfc67497f8aa2757756b5cf493759f245d321fb78914ce125b6d75daa89b5f"},
 ]
 
 [package.dependencies]
@@ -419,53 +438,51 @@ files = [
 
 [[package]]
 name = "nodeenv"
-version = "1.8.0"
+version = "1.9.1"
 description = "Node.js virtual environment builder"
 optional = false
-python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 files = [
-    {file = "nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
-    {file = "nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
 ]
-
-[package.dependencies]
-setuptools = "*"
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+version = "4.2.2"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.2-py3-none-any.whl", hash = "sha256:2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"},
+    {file = "platformdirs-4.2.2.tar.gz", hash = "sha256:38b7b51f512eed9e84a22788b4bce1de17c0adb134d6becb09836e37d8654cd3"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
+type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "pluggy"
-version = "1.4.0"
+version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
-    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
 ]
 
 [package.extras]
@@ -566,17 +583,16 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pygments"
-version = "2.17.2"
+version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pygments-2.17.2-py3-none-any.whl", hash = "sha256:b27c2826c47d0f3219f29554824c30c5e8945175d888647acd804ddd04af846c"},
-    {file = "pygments-2.17.2.tar.gz", hash = "sha256:da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"},
+    {file = "pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"},
+    {file = "pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"},
 ]
 
 [package.extras]
-plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
@@ -671,13 +687,13 @@ rich = ">=12"
 
 [[package]]
 name = "python-dateutil"
-version = "2.8.2"
+version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
-    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
 ]
 
 [package.dependencies]
@@ -685,73 +701,75 @@ six = ">=1.5"
 
 [[package]]
 name = "pyyaml"
-version = "6.0.1"
+version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
 
 [[package]]
 name = "rich"
-version = "13.7.0"
+version = "13.7.1"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.7.0-py3-none-any.whl", hash = "sha256:6da14c108c4866ee9520bbffa71f6fe3962e193b7da68720583850cd4548e235"},
-    {file = "rich-13.7.0.tar.gz", hash = "sha256:5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"},
+    {file = "rich-13.7.1-py3-none-any.whl", hash = "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222"},
+    {file = "rich-13.7.1.tar.gz", hash = "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"},
 ]
 
 [package.dependencies]
@@ -763,13 +781,13 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "ruamel-yaml"
-version = "0.18.5"
+version = "0.18.6"
 description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruamel.yaml-0.18.5-py3-none-any.whl", hash = "sha256:a013ac02f99a69cdd6277d9664689eb1acba07069f912823177c5eced21a6ada"},
-    {file = "ruamel.yaml-0.18.5.tar.gz", hash = "sha256:61917e3a35a569c1133a8f772e1226961bf5a1198bea7e23f06a0841dea1ab0e"},
+    {file = "ruamel.yaml-0.18.6-py3-none-any.whl", hash = "sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636"},
+    {file = "ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"},
 ]
 
 [package.dependencies]
@@ -866,18 +884,19 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "72.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
-    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+    {file = "setuptools-72.2.0-py3-none-any.whl", hash = "sha256:f11dd94b7bae3a156a95ec151f24e4637fb4fa19c878e4d191bfb8b2d82728c4"},
+    {file = "setuptools-72.2.0.tar.gz", hash = "sha256:80aacbf633704e9c8bfa1d99fa5dd4dc59573efcf9e4042c13d3bcef91ac2ef9"},
 ]
 
 [package.extras]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "ordered-set (>=3.1.1)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.11.*)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (<0.4)", "pytest-ruff (>=0.2.1)", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -892,13 +911,13 @@ files = [
 
 [[package]]
 name = "sniffio"
-version = "1.3.0"
+version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
-    {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
 ]
 
 [[package]]
@@ -914,35 +933,35 @@ files = [
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.8.19.20240106"
+version = "2.9.0.20240316"
 description = "Typing stubs for python-dateutil"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-python-dateutil-2.8.19.20240106.tar.gz", hash = "sha256:1f8db221c3b98e6ca02ea83a58371b22c374f42ae5bbdf186db9c9a76581459f"},
-    {file = "types_python_dateutil-2.8.19.20240106-py3-none-any.whl", hash = "sha256:efbbdc54590d0f16152fa103c9879c7d4a00e82078f6e2cf01769042165acaa2"},
+    {file = "types-python-dateutil-2.9.0.20240316.tar.gz", hash = "sha256:5d2f2e240b86905e40944dd787db6da9263f0deabef1076ddaed797351ec0202"},
+    {file = "types_python_dateutil-2.9.0.20240316-py3-none-any.whl", hash = "sha256:6b8cb66d960771ce5ff974e9dd45e38facb81718cc1e208b10b1baccbfdbee3b"},
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
 name = "virtualenv"
-version = "20.25.0"
+version = "20.26.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.25.0-py3-none-any.whl", hash = "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3"},
-    {file = "virtualenv-20.25.0.tar.gz", hash = "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"},
+    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
+    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
 ]
 
 [package.dependencies]
@@ -951,18 +970,18 @@ filelock = ">=3.12.2,<4"
 platformdirs = ">=3.9.1,<5"
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
 name = "zipp"
-version = "3.19.2"
+version = "3.20.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "zipp-3.19.2-py3-none-any.whl", hash = "sha256:f091755f667055f2d02b32c53771a7a6c8b47e1fdbc4b72a8b9072b3eef8015c"},
-    {file = "zipp-3.19.2.tar.gz", hash = "sha256:bf1dcf6450f873a13e952a29504887c89e6de7506209e5b1bcc3460135d4de19"},
+    {file = "zipp-3.20.0-py3-none-any.whl", hash = "sha256:58da6168be89f0be59beb194da1250516fdaa062ccebd30127ac65d30045e10d"},
+    {file = "zipp-3.20.0.tar.gz", hash = "sha256:0145e43d89664cfe1a2e533adc75adafed82fe2da404b4bbb6b026c0157bdb31"},
 ]
 
 [package.extras]


### PR DESCRIPTION
If you take a look at the merge requests in this project, most of them were created by breaking model assumptions and setting individual fields to `Optional`.

This merge request introduces a `CustomBaseModel` that automatically generates `None` values for values that do not match the data types of the model assumptions. In addition, all data types of the fields in the models were set to `Optional`.

This does not immediately make things better, but at least an error is no longer immediately thrown if the model assumptions break. This means that the models and the `mytoyota` lib remain functional within the scope of the information available and can continue to be used by end users if Toyota changes something in the API again.