### PR TITLE
Expose electric status

### DIFF
--- a/mytoyota/models/electric_status.py
+++ b/mytoyota/models/electric_status.py
@@ -1,6 +1,6 @@
 """models for vehicle electric status."""
 from datetime import date
-from typing import Any, Optional
+from typing import Optional
 
 from mytoyota.models.endpoints.electric import ElectricStatusModel
 from mytoyota.utils.conversions import convert_distance
@@ -15,7 +15,9 @@ class ElectricStatus:
         metric: bool = True,
     ):
         """Initialise ElectricStatus."""
-        self._electric_status: Optional[ElectricStatusModel] = electric_status.payload if electric_status else None
+        self._electric_status: Optional[ElectricStatusModel] = (
+            electric_status.payload if electric_status else None
+        )
         self._distance_unit: str = "km" if metric else "mi"
 
     def __repr__(self):
@@ -57,9 +59,10 @@ class ElectricStatus:
         Returns
         -------
             int: Remaining time to full charge in minutes.
-        """            
+
+        """
         return self._electric_status.remaining_charge_time
-    
+
     @property
     def ev_range(self) -> Optional[float]:
         """Electric vehicle range.
@@ -76,7 +79,7 @@ class ElectricStatus:
                 self._electric_status.ev_range.value,
             )
         return None
-    
+
     @property
     def ev_range_with_ac(self) -> Optional[float]:
         """Electric vehicle range with AC.
@@ -93,7 +96,7 @@ class ElectricStatus:
                 self._electric_status.ev_range_with_ac.value,
             )
         return None
-    
+
     @property
     def can_set_next_charging_event(self) -> Optional[bool]:
         """Can set next charging event.
@@ -104,7 +107,7 @@ class ElectricStatus:
 
         """
         return self._electric_status.can_set_next_charging_event if self._electric_status else None
-    
+
     @property
     def last_update_timestamp(self) -> Optional[date]:
         """Last update timestamp.

--- a/mytoyota/models/electric_status.py
+++ b/mytoyota/models/electric_status.py
@@ -1,0 +1,117 @@
+"""models for vehicle electric status."""
+from datetime import date
+from typing import Any, Optional
+
+from mytoyota.models.endpoints.electric import ElectricStatusModel
+from mytoyota.utils.conversions import convert_distance
+
+
+class ElectricStatus:
+    """ElectricStatus."""
+
+    def __init__(
+        self,
+        electric_status: ElectricStatusModel = None,
+        metric: bool = True,
+    ):
+        """Initialise ElectricStatus."""
+        self._electric_status: Optional[ElectricStatusModel] = electric_status.payload if electric_status else None
+        self._distance_unit: str = "km" if metric else "mi"
+
+    def __repr__(self):
+        """Representation of the model."""
+        return " ".join(
+            [
+                f"{k}={getattr(self, k)!s}"
+                for k, v in type(self).__dict__.items()
+                if isinstance(v, property)
+            ],
+        )
+
+    @property
+    def battery_level(self) -> Optional[float]:
+        """Battery level of the vehicle.
+
+        Returns
+        -------
+            float: Battery level of the vehicle in percentage.
+
+        """
+        return self._electric_status.battery_level if self._electric_status else None
+
+    @property
+    def charging_status(self) -> Optional[str]:
+        """Charging status of the vehicle.
+
+        Returns
+        -------
+            str: Charging status of the vehicle.
+
+        """
+        return self._electric_status.charging_status
+
+    @property
+    def remaining_charge_time(self) -> Optional[int]:
+        """Remaining time to full charge in minutes.
+
+        Returns
+        -------
+            int: Remaining time to full charge in minutes.
+        """            
+        return self._electric_status.remaining_charge_time
+    
+    @property
+    def ev_range(self) -> Optional[float]:
+        """Electric vehicle range.
+
+        Returns
+        -------
+            float: Electric vehicle range in the current selected units.
+
+        """
+        if self._electric_status:
+            return convert_distance(
+                self._distance_unit,
+                self._electric_status.ev_range.unit,
+                self._electric_status.ev_range.value,
+            )
+        return None
+    
+    @property
+    def ev_range_with_ac(self) -> Optional[float]:
+        """Electric vehicle range with AC.
+
+        Returns
+        -------
+            float: Electric vehicle range with AC in the current selected units.
+
+        """
+        if self._electric_status:
+            return convert_distance(
+                self._distance_unit,
+                self._electric_status.ev_range_with_ac.unit,
+                self._electric_status.ev_range_with_ac.value,
+            )
+        return None
+    
+    @property
+    def can_set_next_charging_event(self) -> Optional[bool]:
+        """Can set next charging event.
+
+        Returns
+        -------
+            bool: Can set next charging event.
+
+        """
+        return self._electric_status.can_set_next_charging_event if self._electric_status else None
+    
+    @property
+    def last_update_timestamp(self) -> Optional[date]:
+        """Last update timestamp.
+
+        Returns
+        -------
+            date: Last update timestamp.
+
+        """
+        return self._electric_status.last_update_timestamp if self._electric_status else None

--- a/mytoyota/models/vehicle.py
+++ b/mytoyota/models/vehicle.py
@@ -12,6 +12,7 @@ from arrow import Arrow
 
 from mytoyota.api import Api
 from mytoyota.models.dashboard import Dashboard
+from mytoyota.models.electric_status import ElectricStatus
 from mytoyota.models.endpoints.vehicle_guid import VehicleGuidModel
 from mytoyota.models.location import Location
 from mytoyota.models.lock_status import LockStatus
@@ -168,6 +169,21 @@ class Vehicle:
             if "health_status" in self._endpoint_data
             else None,
             self._metric,
+        )
+
+    @property
+    def electric_status(self) -> Optional[ElectricStatus]:
+        """Returns the Electric Status of the vehicle.
+
+        Returns
+        -------
+            Electric Status
+
+        """
+        return (
+            ElectricStatus(self._endpoint_data["electric_status"])
+            if "electric_status" in self._endpoint_data
+            else None
         )
 
     @property

--- a/simple_client_example.py
+++ b/simple_client_example.py
@@ -51,6 +51,8 @@ async def get_information():
 
         # Dashboard Information
         pp.pprint(f"Dashboard: {car.dashboard}")
+        # Electric Status Information
+        pp.pprint(f"Electric Status: {car.electric_status}")
         # Location Information
         pp.pprint(f"Location: {car.location}")
         # Lock Status


### PR DESCRIPTION
Since I am owner of Toyota's EV, model BZ4X, it was useful for me to find this library already built. It was missing EV specific statuses that was already part of response. My guess is that BZ4X was not available for testing so it was not exposed in final output.

I added `ElectricStatus` model and populated attributes with information from payload. There were no need for many transformation from sourced data. I have tested library locally with different status on my car. Everything worked smoothly. 

These steps have been performed successfully:

- :heavy_check_mark: **passed** `poetry run pre-commit run --all-files `  
- :heavy_check_mark: **passed** `pytest tests/.`

This is my first contribution to this project but I have plan to be active user, tester and contributor. Also my plan is to contribute to Home Assistant project https://github.com/DurgNomis-drol/ha_toyota in order to make these data useful for smart home automation.

As side note, this PR should solve question from here: https://github.com/DurgNomis-drol/mytoyota/discussions/371