### PR TITLE
fix(summary, trips): conversion from L/100km to MPG

### DIFF
--- a/mytoyota/models/summary.py
+++ b/mytoyota/models/summary.py
@@ -187,7 +187,7 @@ class Summary:
             return (
                 round(avg_fuel_consumed, 3)
                 if self._metric
-                else round(235.215 * avg_fuel_consumed, 3)
+                else round(235.215 / avg_fuel_consumed, 3)
             )
 
         return 0.0

--- a/mytoyota/models/trips.py
+++ b/mytoyota/models/trips.py
@@ -161,7 +161,7 @@ class Trip:
             return (
                 round(avg_fuel_consumed, 3)
                 if self._metric
-                else round(235.215 * avg_fuel_consumed, 3)
+                else round(235.215 / avg_fuel_consumed, 3)
             )
 
         return 0.0


### PR DESCRIPTION
- Fixed the fuel consumption calculation in the Summary and Trip classes by switching from multiplying to dividing by 235.215 for imperial units. Since `avg_fuel_consumed` is assumed to be in L/100km, dividing by 235.215 converts it correctly to MPG.
- Ensures that the Summary and Trip classes now report MPG accurately.